### PR TITLE
Refactor: break up SearchRepository, normalize storage, + 2 fixes

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -83,12 +83,12 @@ Expected benefit:
 
 ### Phase 4: Normalize storage
 
-Status: in progress
+Status: done
 
 - Inventory SharedPreferences and DataStore usage. Done (see map below).
 - Centralize ad hoc preference file/key names into one registry (`Prefs`). Done.
-- Decide which state belongs in DataStore, cache files, or migration-only SharedPreferences. Pending
-  (these move persisted data, so they need explicit sign-off — see open decisions).
+- Decide which state belongs in DataStore, cache files, or migration-only SharedPreferences. Done
+  (see ownership principle and resolved decisions below — no data relocation needed).
 
 Expected benefit:
 
@@ -117,16 +117,30 @@ SharedPreferences (now all named via `Prefs`):
 | `history` | `HistoryRepository` | `history_ids` (JSON) |
 | `contact_chat_actions` | `ContactActionsRepository` | per-contact package (keys are contact ids) |
 
-#### Open decisions (move persisted data — need sign-off)
+#### Ownership principle
 
-- `min_icon_size` lives in both DataStore (`settings`, source of truth) and `search_launcher_prefs`
-  (synchronous boot cache to avoid first-frame icon flicker). Keep the dual storage, or replace the
-  cache with a blocking first read / a smarter default?
-- `observed_history_limit` and `last_reindex_timestamp` are launcher-internal ints in
-  `search_launcher_prefs`; they could move to DataStore for consistency, but that needs a migration.
-- Backup/restore (`BackupManager`) currently snapshots the DataStore `settings` plus the JSON
-  repositories, but not `privacy_prefs`, `window_prefs`, `active_search`, or `search_launcher_prefs`.
-  Confirm that exclusion is intentional before consolidating.
+DataStore (`settings`) owns durable, user-facing settings that should survive backup/restore.
+SharedPreferences owns device-local, internal, transient, or synchronously-read state. Reviewed
+against this principle, every current store is already in the right place — so Phase 4 is about
+making the split legible, not relocating data.
+
+#### Resolved decisions
+
+- `min_icon_size` dual storage: KEEP. DataStore is the source of truth; the `search_launcher_prefs`
+  copy is a synchronous boot cache that prevents real icon flicker on cold start. Encapsulated into
+  `MinIconSize` (`flow` / `cached` / `updateCache`) so the read/write/default logic lives in one
+  named place instead of inline in `SearchScreen`.
+- `observed_history_limit`, `last_reindex_timestamp`: STAY in SharedPreferences.
+  `observed_history_limit` is read synchronously on the cold-start hot path (to size the initial
+  history frame without jumpiness); `last_reindex_timestamp` is device-local reindex-throttle state.
+  Neither is a user setting, so moving them to async DataStore would add complexity for no benefit.
+- Backup exclusions (`privacy_prefs`, `window_prefs`, `active_search`, `search_launcher_prefs`):
+  INTENTIONAL. Privacy consent should re-prompt on a new device, `active_query` is transient, and the
+  rest are device-specific. `min_icon_size`'s authoritative copy already rides along in the
+  backed-up DataStore.
+
+Phase 4 is effectively complete: storage is inventoried, named via `Prefs`, the ownership principle
+is documented, and the one real redundancy (`min_icon_size`) is encapsulated.
 
 ## Change Log
 
@@ -154,3 +168,8 @@ SharedPreferences (now all named via `Prefs`):
   `ContactActionsRepository`, and the Favorites/Snippets/SearchShortcut/History repositories.
   Behavior preserved; `./gradlew testDebugUnitTest assembleDebug` passes. Store-migration decisions
   deferred (see Phase 4 open decisions).
+- 2026-06-02: Phase 4 complete. Reviewed each store against an ownership principle (DataStore =
+  durable user settings; SharedPreferences = device-local/internal/transient) and confirmed no data
+  needs relocating. Encapsulated the `min_icon_size` DataStore-plus-boot-cache pattern into
+  `MinIconSize`, removing the duplicated default logic and inline SharedPreferences plumbing from
+  `SearchScreen`. Behavior preserved; `./gradlew testDebugUnitTest assembleDebug` passes.

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -71,7 +71,7 @@ Expected benefit:
 
 Status: in progress
 
-- Extract indexers: apps, shortcuts, contacts, snippets.
+- Extract indexers: apps, shortcuts, contacts, snippets. Done.
 - Extract ranking and learned-query scoring. Done.
 - Extract `SearchableDocument -> SearchResult` conversion. Done.
 - Extract icon cache/disk persistence. Done.
@@ -109,3 +109,8 @@ Expected benefit:
   Kotlin LOC now 14,581. `SearchRepository.kt` is 2,637 lines.
 - 2026-06-02: Extracted `SearchResultFactory` from `SearchRepository`.
   Kotlin LOC now 14,633. `SearchRepository.kt` is 2,301 lines, `SearchResultFactory.kt` is 409 lines.
+- 2026-06-02: Extracted `AppIndexer`, `ShortcutIndexer` (dynamic/static/custom), `ContactIndexer`,
+  and `SnippetIndexer` from `SearchRepository`. The repo keeps AppSearch persistence and
+  orchestration; indexers are pure document builders (icon-caching side effects retained). Behavior
+  preserved; `./gradlew testDebugUnitTest assembleDebug` passes. Kotlin LOC now 14,747.
+  `SearchRepository.kt` is 1,968 lines. This completes the Phase 3 indexer split.

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -83,16 +83,50 @@ Expected benefit:
 
 ### Phase 4: Normalize storage
 
-Status: pending
+Status: in progress
 
-- Inventory SharedPreferences and DataStore usage.
-- Decide which state belongs in DataStore, cache files, or migration-only SharedPreferences.
-- Remove ad hoc preference names where possible.
+- Inventory SharedPreferences and DataStore usage. Done (see map below).
+- Centralize ad hoc preference file/key names into one registry (`Prefs`). Done.
+- Decide which state belongs in DataStore, cache files, or migration-only SharedPreferences. Pending
+  (these move persisted data, so they need explicit sign-off — see open decisions).
 
 Expected benefit:
 
 - Easier backup/restore and reset behavior.
 - Less mystery around which file owns which user-visible setting.
+
+#### Storage inventory (2026-06-02)
+
+DataStore (async, user-facing settings):
+
+- `settings` — all `PreferencesKeys` (theme, dark/oled mode, wallpaper uri, show widgets, first run,
+  store web history, history limit, min icon size, auto-theme, search shortcuts enabled).
+- `onboarding` — separate store owned by `OnboardingManager`.
+
+SharedPreferences (now all named via `Prefs`):
+
+| File | Owner | Keys |
+| --- | --- | --- |
+| `privacy_prefs` | `SearchLauncherApp` | `consent_granted`, `asked_default_launcher` |
+| `active_search` | `MainActivity` | `active_query`, `active_query_time` |
+| `search_launcher_prefs` | `SearchScreen` + `SearchRepository` | `min_icon_size` (boot cache), `observed_history_limit`, `last_reindex_timestamp` |
+| `window_prefs` | `SearchScreen` | `keyboard_height` |
+| `favorites` | `FavoritesRepository` | `favorite_ids_ordered`, `favorite_ids` (legacy set) |
+| `search_shortcuts` | `SearchShortcutRepository` | `shortcuts` (JSON) |
+| `quick_copy` | `SnippetsRepository` | `items` (JSON) |
+| `history` | `HistoryRepository` | `history_ids` (JSON) |
+| `contact_chat_actions` | `ContactActionsRepository` | per-contact package (keys are contact ids) |
+
+#### Open decisions (move persisted data — need sign-off)
+
+- `min_icon_size` lives in both DataStore (`settings`, source of truth) and `search_launcher_prefs`
+  (synchronous boot cache to avoid first-frame icon flicker). Keep the dual storage, or replace the
+  cache with a blocking first read / a smarter default?
+- `observed_history_limit` and `last_reindex_timestamp` are launcher-internal ints in
+  `search_launcher_prefs`; they could move to DataStore for consistency, but that needs a migration.
+- Backup/restore (`BackupManager`) currently snapshots the DataStore `settings` plus the JSON
+  repositories, but not `privacy_prefs`, `window_prefs`, `active_search`, or `search_launcher_prefs`.
+  Confirm that exclusion is intentional before consolidating.
 
 ## Change Log
 
@@ -114,3 +148,9 @@ Expected benefit:
   orchestration; indexers are pure document builders (icon-caching side effects retained). Behavior
   preserved; `./gradlew testDebugUnitTest assembleDebug` passes. Kotlin LOC now 14,747.
   `SearchRepository.kt` is 1,968 lines. This completes the Phase 3 indexer split.
+- 2026-06-02: Phase 4 inventory complete. Centralized all SharedPreferences file/key names into a
+  single `Prefs` registry (byte-identical string values, no data migration). Updated 9 call sites
+  across `SearchLauncherApp`, `MainActivity`, `SearchScreen`, `SearchRepository`,
+  `ContactActionsRepository`, and the Favorites/Snippets/SearchShortcut/History repositories.
+  Behavior preserved; `./gradlew testDebugUnitTest assembleDebug` passes. Store-migration decisions
+  deferred (see Phase 4 open decisions).

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -42,11 +42,14 @@ find app/src/main/java app/src/test/java -name '*.kt' -print0 | xargs -0 wc -l
 
 ### Phase 1: Remove duplicated UI/action code
 
-Status: in progress
+Status: done (one optional item dropped)
 
 - Extract shared app actions menu from `SearchResultItem` and `FavoritesRow`. Done.
 - Extract result launching from `SearchScreen` and `MainActivity`. Done.
 - Make result rows delegate actions instead of knowing repositories directly where practical.
+  Dropped: in Compose, rows pulling the app singleton from context is idiomatic; threading action
+  callbacks through every call site would add indirection for working UI without real benefit
+  (and cuts against "avoid hiding logic in vague abstractions").
 
 Expected benefit:
 
@@ -56,11 +59,15 @@ Expected benefit:
 
 ### Phase 2: Extract contact actions
 
-Status: in progress
+Status: done
 
 - Move contact chat/SMS/call/email discovery and launch code out of `SearchRepository`. Done.
-- Keep `SearchRepository` focused on search/index results.
+- Keep `SearchRepository` focused on search/index results. Done.
 - Add focused tests for Telegram MIME detection, phone fallback, SMS, email, and last-used ordering.
+  Done — extracted the intent-building (`buildContactActionIntents`) and last-used sort
+  (`orderByLastUsed`) into pure functions and covered them, plus `chatPackageFromMimeType`, in
+  `ContactActionsRepositoryTest` (14 cases). The `ContentResolver` query paths remain
+  integration-only by design.
 
 Expected benefit:
 
@@ -69,7 +76,7 @@ Expected benefit:
 
 ### Phase 3: Split search/index responsibilities
 
-Status: in progress
+Status: done
 
 - Extract indexers: apps, shortcuts, contacts, snippets. Done.
 - Extract ranking and learned-query scoring. Done.
@@ -173,3 +180,7 @@ is documented, and the one real redundancy (`min_icon_size`) is encapsulated.
   needs relocating. Encapsulated the `min_icon_size` DataStore-plus-boot-cache pattern into
   `MinIconSize`, removing the duplicated default logic and inline SharedPreferences plumbing from
   `SearchScreen`. Behavior preserved; `./gradlew testDebugUnitTest assembleDebug` passes.
+- 2026-06-03: Phase 2 tests added. Extracted `buildContactActionIntents` and `orderByLastUsed` as
+  pure functions and covered them plus `chatPackageFromMimeType` in `ContactActionsRepositoryTest`
+  (14 cases). Dropped the optional Phase 1 "rows delegate actions" item (see Phase 1 note). All four
+  phases now done; refactor considered complete. `./gradlew testDebugUnitTest assembleDebug` passes.

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,0 +1,111 @@
+# SearchLauncher Simplification Plan
+
+## Goal
+
+Simplify the codebase and make it easier to understand without changing launcher behavior.
+
+Primary measures:
+
+- Reduce very large files by extracting cohesive modules.
+- Remove duplicated launch/menu/action logic.
+- Make storage and action handling easier to reason about.
+- Keep behavior covered by `./gradlew testDebugUnitTest assembleDebug`.
+
+## Baseline
+
+Captured: 2026-06-02
+
+Kotlin LOC:
+
+- Total: 14,541
+- `app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt`: 3,164
+- `app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt`: 1,606
+- `app/src/main/java/com/searchlauncher/app/ui/SettingsScreen.kt`: 1,115
+- `app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt`: 1,064
+- `app/src/main/java/com/searchlauncher/app/ui/components/SearchResultItem.kt`: 478
+- `app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt`: 393
+
+Baseline command:
+
+```sh
+find app/src/main/java app/src/test/java -name '*.kt' -print0 | xargs -0 wc -l
+```
+
+## Principles
+
+- Prefer behavior-preserving extraction over rewrites.
+- Keep one change small enough to verify independently.
+- Move code toward named concepts: launchers, actions, indexers, ranking, icon storage.
+- Avoid reducing LOC by hiding logic in vague abstractions.
+
+## Work Plan
+
+### Phase 1: Remove duplicated UI/action code
+
+Status: in progress
+
+- Extract shared app actions menu from `SearchResultItem` and `FavoritesRow`. Done.
+- Extract result launching from `SearchScreen` and `MainActivity`. Done.
+- Make result rows delegate actions instead of knowing repositories directly where practical.
+
+Expected benefit:
+
+- Fewer divergent App Info/favorite/uninstall implementations.
+- One place to add future app context actions.
+- Lower complexity in `SearchScreen`.
+
+### Phase 2: Extract contact actions
+
+Status: in progress
+
+- Move contact chat/SMS/call/email discovery and launch code out of `SearchRepository`. Done.
+- Keep `SearchRepository` focused on search/index results.
+- Add focused tests for Telegram MIME detection, phone fallback, SMS, email, and last-used ordering.
+
+Expected benefit:
+
+- Contact action behavior becomes easier to inspect and extend.
+- Search indexing stops absorbing unrelated UI action responsibilities.
+
+### Phase 3: Split search/index responsibilities
+
+Status: in progress
+
+- Extract indexers: apps, shortcuts, contacts, snippets.
+- Extract ranking and learned-query scoring. Done.
+- Extract `SearchableDocument -> SearchResult` conversion. Done.
+- Extract icon cache/disk persistence. Done.
+
+Expected benefit:
+
+- `SearchRepository.kt` becomes orchestration rather than the whole search subsystem.
+- Ranking/indexing/icon changes become independently testable.
+
+### Phase 4: Normalize storage
+
+Status: pending
+
+- Inventory SharedPreferences and DataStore usage.
+- Decide which state belongs in DataStore, cache files, or migration-only SharedPreferences.
+- Remove ad hoc preference names where possible.
+
+Expected benefit:
+
+- Easier backup/restore and reset behavior.
+- Less mystery around which file owns which user-visible setting.
+
+## Change Log
+
+- 2026-06-02: Created plan and LOC baseline.
+- 2026-06-02: Extracted shared `AppActionsMenuItems` from `SearchResultItem` and `FavoritesRow`.
+  Kotlin LOC now 14,518. `SearchResultItem.kt` is 399 lines, `FavoritesRow.kt` is 365 lines.
+- 2026-06-02: Extracted `ContactActionsRepository` from `SearchRepository`.
+  Kotlin LOC now 14,510. `SearchRepository.kt` is 2,887 lines.
+- 2026-06-02: Extracted shared `ResultLauncher` from `SearchScreen` and `MainActivity`.
+  Kotlin LOC now 14,509. `SearchScreen.kt` is 1,427 lines, `MainActivity.kt` is 1,036 lines.
+- 2026-06-02: Extracted `IconRepository` from `SearchRepository`.
+  Kotlin LOC now 14,531. `SearchRepository.kt` is 2,801 lines.
+- 2026-06-02: Extracted `SearchRanker` from `SearchRepository`.
+  Kotlin LOC now 14,581. `SearchRepository.kt` is 2,637 lines.
+- 2026-06-02: Extracted `SearchResultFactory` from `SearchRepository`.
+  Kotlin LOC now 14,633. `SearchRepository.kt` is 2,301 lines, `SearchResultFactory.kt` is 409 lines.

--- a/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
+++ b/app/src/main/java/com/searchlauncher/app/SearchLauncherApp.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.os.Build
 import com.searchlauncher.app.data.FavoritesRepository
 import com.searchlauncher.app.data.HistoryRepository
+import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchShortcutRepository
 import com.searchlauncher.app.data.SnippetsRepository
@@ -132,8 +133,8 @@ class SearchLauncherApp : Application() {
   companion object {
     const val NOTIFICATION_CHANNEL_ID = "searchlauncher_service"
     const val NOTIFICATION_ID = 1001
-    private const val PREFS_NAME = "privacy_prefs"
-    private const val KEY_CONSENT_GRANTED = "consent_granted"
-    private const val KEY_ASKED_DEFAULT_LAUNCHER = "asked_default_launcher"
+    private const val PREFS_NAME = Prefs.Privacy.FILE
+    private const val KEY_CONSENT_GRANTED = Prefs.Privacy.CONSENT_GRANTED
+    private const val KEY_ASKED_DEFAULT_LAUNCHER = Prefs.Privacy.ASKED_DEFAULT_LAUNCHER
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
@@ -22,6 +22,10 @@ class AppIndexer(private val context: Context) {
       context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
 
     val apps = mutableListOf<AppSearchDocument>()
+    // Apps are addressed by package id everywhere (search, favorites, history, the app list), so we
+    // keep one document per package. A package can expose several launcher activities (e.g. Tasker)
+    // or appear in multiple profiles, which would otherwise yield colliding ids.
+    val seenPackages = mutableSetOf<String>()
 
     for (profile in launcherApps.profiles) {
       pauseCheck()
@@ -35,6 +39,7 @@ class AppIndexer(private val context: Context) {
           try {
             val appName = info.label.toString()
             val packageName = info.componentName.packageName
+            if (!seenPackages.add(packageName)) continue
 
             val appInfo = info.applicationInfo
             val category =

--- a/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
@@ -1,0 +1,79 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.LauncherApps
+import io.sentry.Sentry
+
+/**
+ * Builds AppSearch documents for launchable apps across all user profiles.
+ *
+ * This is a pure reader: it queries [LauncherApps] and returns documents. Persisting them (and
+ * cleaning up zombie entries) is the caller's responsibility.
+ */
+class AppIndexer(private val context: Context) {
+
+  /**
+   * Returns one document per launchable activity across all profiles. [pauseCheck] is invoked
+   * between profiles and apps so indexing yields to active searches.
+   */
+  suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+    val launcherApps =
+      context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+
+    val apps = mutableListOf<AppSearchDocument>()
+
+    for (profile in launcherApps.profiles) {
+      pauseCheck()
+      try {
+        // fetch activities directly per profile. This is more efficient and safer
+        // than getInstalledPackages which is prone to DeadObjectException.
+        val activityList = launcherApps.getActivityList(null, profile)
+
+        for (info in activityList) {
+          pauseCheck()
+          try {
+            val appName = info.label.toString()
+            val packageName = info.componentName.packageName
+
+            val appInfo = info.applicationInfo
+            val category =
+              when (appInfo.category) {
+                ApplicationInfo.CATEGORY_GAME -> "Game"
+                ApplicationInfo.CATEGORY_AUDIO -> "Audio"
+                ApplicationInfo.CATEGORY_VIDEO -> "Video"
+                ApplicationInfo.CATEGORY_IMAGE -> "Image"
+                ApplicationInfo.CATEGORY_SOCIAL -> "Social"
+                ApplicationInfo.CATEGORY_NEWS -> "News"
+                ApplicationInfo.CATEGORY_MAPS -> "Maps"
+                ApplicationInfo.CATEGORY_PRODUCTIVITY -> "Productivity"
+                else -> "Application"
+              }
+
+            apps.add(
+              AppSearchDocument(
+                namespace = "apps",
+                id = packageName,
+                name = appName,
+                score = 2,
+                description = category,
+              )
+            )
+          } catch (e: Exception) {
+            // Ignore individual app failures
+          }
+        }
+      } catch (e: android.os.DeadObjectException) {
+        android.util.Log.w(
+          "SearchRepository",
+          "System unavailable querying apps for profile $profile, skipping",
+        )
+      } catch (e: Exception) {
+        android.util.Log.e("SearchRepository", "Error querying apps for profile $profile", e)
+        Sentry.captureException(e)
+      }
+    }
+
+    return apps
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
@@ -18,8 +18,7 @@ class AppIndexer(private val context: Context) {
    * between profiles and apps so indexing yields to active searches.
    */
   suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
-    val launcherApps =
-      context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
 
     val apps = mutableListOf<AppSearchDocument>()
     // Apps are addressed by package id everywhere (search, favorites, history, the app list), so we

--- a/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
@@ -1,0 +1,273 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ContactActionsRepository(private val context: Context) {
+  suspend fun getContactActions(contact: SearchResult.Contact): List<ContactChatAction> =
+    withContext(Dispatchers.IO) {
+      val permission = context.checkSelfPermission(android.Manifest.permission.READ_CONTACTS)
+      if (permission != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+        return@withContext emptyList()
+      }
+
+      val actionsByPackage = linkedMapOf<String, ContactChatAction>()
+      val dataCursor =
+        context.contentResolver.query(
+          android.provider.ContactsContract.Data.CONTENT_URI,
+          arrayOf(
+            android.provider.ContactsContract.Data._ID,
+            android.provider.ContactsContract.Data.MIMETYPE,
+            android.provider.ContactsContract.Data.DATA1,
+          ),
+          "${android.provider.ContactsContract.Data.CONTACT_ID} = ?",
+          arrayOf(contact.contactId.toString()),
+          null,
+        )
+
+      dataCursor?.use {
+        val idIndex = it.getColumnIndex(android.provider.ContactsContract.Data._ID)
+        val mimeIndex = it.getColumnIndex(android.provider.ContactsContract.Data.MIMETYPE)
+        val data1Index = it.getColumnIndex(android.provider.ContactsContract.Data.DATA1)
+        while (it.moveToNext()) {
+          val mimeType = it.getString(mimeIndex) ?: continue
+          val packageName = chatPackageFromMimeType(mimeType) ?: continue
+          if (!isPackageInstalled(packageName)) continue
+          actionsByPackage.putIfAbsent(
+            packageName,
+            ContactChatAction(
+              label = getApplicationLabel(packageName) ?: packageName,
+              packageName = packageName,
+              dataId = it.getLong(idIndex),
+              phoneNumber = it.getString(data1Index),
+              icon = getApplicationIcon(packageName),
+            ),
+          )
+        }
+      }
+
+      val phoneNumber = getPrimaryPhoneNumber(contact.contactId)
+      if (phoneNumber != null && isPackageInstalled(WHATSAPP_PACKAGE)) {
+        actionsByPackage.putIfAbsent(
+          WHATSAPP_PACKAGE,
+          ContactChatAction(
+            label = getApplicationLabel(WHATSAPP_PACKAGE) ?: "WhatsApp",
+            packageName = WHATSAPP_PACKAGE,
+            phoneNumber = phoneNumber,
+            icon = getApplicationIcon(WHATSAPP_PACKAGE),
+          ),
+        )
+      }
+      if (phoneNumber != null) {
+        actionsByPackage.putIfAbsent(
+          SMS_ACTION_KEY,
+          ContactChatAction(
+            label = "SMS",
+            packageName = SMS_ACTION_KEY,
+            phoneNumber = phoneNumber,
+            icon = context.getDrawable(android.R.drawable.sym_action_chat),
+          ),
+        )
+        actionsByPackage.putIfAbsent(
+          CALL_ACTION_KEY,
+          ContactChatAction(
+            label = "Call",
+            packageName = CALL_ACTION_KEY,
+            phoneNumber = phoneNumber,
+            icon = context.getDrawable(android.R.drawable.ic_menu_call),
+          ),
+        )
+      }
+      val emailAddress = getPrimaryEmailAddress(contact.contactId)
+      if (emailAddress != null) {
+        actionsByPackage.putIfAbsent(
+          EMAIL_ACTION_KEY,
+          ContactChatAction(
+            label = "Email",
+            packageName = EMAIL_ACTION_KEY,
+            phoneNumber = emailAddress,
+            icon = context.getDrawable(android.R.drawable.ic_dialog_email),
+          ),
+        )
+      }
+
+      val actions = actionsByPackage.values.toList()
+      val lastPackage = getLastContactActionPackage(contact.id)
+      if (lastPackage == null) {
+        actions
+      } else {
+        actions.sortedBy { if (it.packageName == lastPackage) 0 else 1 }
+      }
+    }
+
+  fun launchContactAction(contact: SearchResult.Contact, action: ContactChatAction): Boolean {
+    val intents = buildList {
+      if (action.packageName == CALL_ACTION_KEY && action.phoneNumber != null) {
+        add(Intent(Intent.ACTION_DIAL, Uri.parse("tel:${Uri.encode(action.phoneNumber)}")))
+      }
+
+      if (action.packageName == SMS_ACTION_KEY && action.phoneNumber != null) {
+        add(Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${Uri.encode(action.phoneNumber)}")))
+      }
+
+      if (action.packageName == EMAIL_ACTION_KEY && action.phoneNumber != null) {
+        add(Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:${Uri.encode(action.phoneNumber)}")))
+      }
+
+      if (action.dataId != null) {
+        add(
+          Intent(
+              Intent.ACTION_VIEW,
+              Uri.withAppendedPath(
+                android.provider.ContactsContract.Data.CONTENT_URI,
+                action.dataId.toString(),
+              ),
+            )
+            .setPackage(action.packageName)
+        )
+      }
+
+      if (action.packageName == WHATSAPP_PACKAGE && action.phoneNumber != null) {
+        val normalizedPhone =
+          com.searchlauncher.app.util.ContactUtils.normalizePhoneNumber(action.phoneNumber)
+        if (normalizedPhone != null) {
+          add(
+            Intent(Intent.ACTION_VIEW, Uri.parse("https://wa.me/$normalizedPhone"))
+              .setPackage(WHATSAPP_PACKAGE)
+          )
+        }
+      }
+
+      add(
+        Intent(
+            Intent.ACTION_VIEW,
+            Uri.withAppendedPath(
+              android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
+              contact.lookupKey,
+            ),
+          )
+          .setPackage(action.packageName)
+      )
+    }
+
+    for (intent in intents) {
+      try {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+        setLastContactActionPackage(contact.id, action.packageName)
+        return true
+      } catch (e: Exception) {
+        // Try the next route.
+      }
+    }
+    return false
+  }
+
+  internal fun chatPackageFromMimeType(mimeType: String): String? =
+    KNOWN_CHAT_PACKAGES.firstOrNull { packageName ->
+      mimeType.contains(packageName, ignoreCase = true)
+    }
+
+  private fun getPrimaryPhoneNumber(contactId: Long): String? {
+    val cursor =
+      context.contentResolver.query(
+        android.provider.ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+        arrayOf(android.provider.ContactsContract.CommonDataKinds.Phone.NUMBER),
+        "${android.provider.ContactsContract.CommonDataKinds.Phone.CONTACT_ID} = ?",
+        arrayOf(contactId.toString()),
+        "${android.provider.ContactsContract.CommonDataKinds.Phone.IS_PRIMARY} DESC",
+      )
+
+    cursor?.use {
+      val numberIndex =
+        it.getColumnIndex(android.provider.ContactsContract.CommonDataKinds.Phone.NUMBER)
+      while (it.moveToNext()) {
+        val number = it.getString(numberIndex)
+        if (!number.isNullOrBlank()) return number
+      }
+    }
+    return null
+  }
+
+  private fun getPrimaryEmailAddress(contactId: Long): String? {
+    val cursor =
+      context.contentResolver.query(
+        android.provider.ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+        arrayOf(android.provider.ContactsContract.CommonDataKinds.Email.ADDRESS),
+        "${android.provider.ContactsContract.CommonDataKinds.Email.CONTACT_ID} = ?",
+        arrayOf(contactId.toString()),
+        "${android.provider.ContactsContract.CommonDataKinds.Email.IS_PRIMARY} DESC",
+      )
+
+    cursor?.use {
+      val addressIndex =
+        it.getColumnIndex(android.provider.ContactsContract.CommonDataKinds.Email.ADDRESS)
+      while (it.moveToNext()) {
+        val address = it.getString(addressIndex)
+        if (!address.isNullOrBlank()) return address
+      }
+    }
+    return null
+  }
+
+  private fun isPackageInstalled(packageName: String): Boolean =
+    try {
+      context.packageManager.getPackageInfo(packageName, 0)
+      true
+    } catch (e: Exception) {
+      false
+    }
+
+  private fun getApplicationLabel(packageName: String): String? =
+    try {
+      val appInfo = context.packageManager.getApplicationInfo(packageName, 0)
+      context.packageManager.getApplicationLabel(appInfo).toString()
+    } catch (e: Exception) {
+      null
+    }
+
+  private fun getApplicationIcon(packageName: String) =
+    try {
+      context.packageManager.getApplicationIcon(packageName)
+    } catch (e: Exception) {
+      null
+    }
+
+  private fun getLastContactActionPackage(contactId: String): String? =
+    context
+      .getSharedPreferences(CONTACT_ACTION_PREFS, Context.MODE_PRIVATE)
+      .getString(contactId, null)
+
+  private fun setLastContactActionPackage(contactId: String, packageName: String) {
+    context
+      .getSharedPreferences(CONTACT_ACTION_PREFS, Context.MODE_PRIVATE)
+      .edit()
+      .putString(contactId, packageName)
+      .apply()
+  }
+
+  companion object {
+    private const val CONTACT_ACTION_PREFS = "contact_chat_actions"
+    private const val CALL_ACTION_KEY = "com.searchlauncher.action.CALL_CONTACT"
+    private const val SMS_ACTION_KEY = "com.searchlauncher.action.SMS_CONTACT"
+    private const val EMAIL_ACTION_KEY = "com.searchlauncher.action.EMAIL_CONTACT"
+    private const val WHATSAPP_PACKAGE = "com.whatsapp"
+    private val KNOWN_CHAT_PACKAGES =
+      setOf(
+        WHATSAPP_PACKAGE,
+        "com.whatsapp.w4b",
+        "org.telegram.messenger",
+        "org.thunderdog.challegram",
+        "org.telegram.plus",
+        "com.facebook.orca",
+        "com.viber.voip",
+        "com.signal",
+        "org.thoughtcrime.securesms",
+        "com.google.android.apps.messaging",
+        "com.skype.raider",
+      )
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
@@ -238,19 +238,18 @@ class ContactActionsRepository(private val context: Context) {
 
   private fun getLastContactActionPackage(contactId: String): String? =
     context
-      .getSharedPreferences(CONTACT_ACTION_PREFS, Context.MODE_PRIVATE)
+      .getSharedPreferences(Prefs.ContactActions.FILE, Context.MODE_PRIVATE)
       .getString(contactId, null)
 
   private fun setLastContactActionPackage(contactId: String, packageName: String) {
     context
-      .getSharedPreferences(CONTACT_ACTION_PREFS, Context.MODE_PRIVATE)
+      .getSharedPreferences(Prefs.ContactActions.FILE, Context.MODE_PRIVATE)
       .edit()
       .putString(contactId, packageName)
       .apply()
   }
 
   companion object {
-    private const val CONTACT_ACTION_PREFS = "contact_chat_actions"
     private const val CALL_ACTION_KEY = "com.searchlauncher.action.CALL_CONTACT"
     private const val SMS_ACTION_KEY = "com.searchlauncher.action.SMS_CONTACT"
     private const val EMAIL_ACTION_KEY = "com.searchlauncher.action.EMAIL_CONTACT"

--- a/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ContactActionsRepository.kt
@@ -95,63 +95,11 @@ class ContactActionsRepository(private val context: Context) {
       }
 
       val actions = actionsByPackage.values.toList()
-      val lastPackage = getLastContactActionPackage(contact.id)
-      if (lastPackage == null) {
-        actions
-      } else {
-        actions.sortedBy { if (it.packageName == lastPackage) 0 else 1 }
-      }
+      orderByLastUsed(actions, getLastContactActionPackage(contact.id))
     }
 
   fun launchContactAction(contact: SearchResult.Contact, action: ContactChatAction): Boolean {
-    val intents = buildList {
-      if (action.packageName == CALL_ACTION_KEY && action.phoneNumber != null) {
-        add(Intent(Intent.ACTION_DIAL, Uri.parse("tel:${Uri.encode(action.phoneNumber)}")))
-      }
-
-      if (action.packageName == SMS_ACTION_KEY && action.phoneNumber != null) {
-        add(Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${Uri.encode(action.phoneNumber)}")))
-      }
-
-      if (action.packageName == EMAIL_ACTION_KEY && action.phoneNumber != null) {
-        add(Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:${Uri.encode(action.phoneNumber)}")))
-      }
-
-      if (action.dataId != null) {
-        add(
-          Intent(
-              Intent.ACTION_VIEW,
-              Uri.withAppendedPath(
-                android.provider.ContactsContract.Data.CONTENT_URI,
-                action.dataId.toString(),
-              ),
-            )
-            .setPackage(action.packageName)
-        )
-      }
-
-      if (action.packageName == WHATSAPP_PACKAGE && action.phoneNumber != null) {
-        val normalizedPhone =
-          com.searchlauncher.app.util.ContactUtils.normalizePhoneNumber(action.phoneNumber)
-        if (normalizedPhone != null) {
-          add(
-            Intent(Intent.ACTION_VIEW, Uri.parse("https://wa.me/$normalizedPhone"))
-              .setPackage(WHATSAPP_PACKAGE)
-          )
-        }
-      }
-
-      add(
-        Intent(
-            Intent.ACTION_VIEW,
-            Uri.withAppendedPath(
-              android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
-              contact.lookupKey,
-            ),
-          )
-          .setPackage(action.packageName)
-      )
-    }
+    val intents = buildContactActionIntents(contact, action)
 
     for (intent in intents) {
       try {
@@ -165,6 +113,73 @@ class ContactActionsRepository(private val context: Context) {
     }
     return false
   }
+
+  /**
+   * Builds the ordered list of intents to try for [action], most specific first, always ending with
+   * a generic contact-lookup fallback. Pure: no side effects, so it is unit-testable.
+   */
+  internal fun buildContactActionIntents(
+    contact: SearchResult.Contact,
+    action: ContactChatAction,
+  ): List<Intent> = buildList {
+    if (action.packageName == CALL_ACTION_KEY && action.phoneNumber != null) {
+      add(Intent(Intent.ACTION_DIAL, Uri.parse("tel:${Uri.encode(action.phoneNumber)}")))
+    }
+
+    if (action.packageName == SMS_ACTION_KEY && action.phoneNumber != null) {
+      add(Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${Uri.encode(action.phoneNumber)}")))
+    }
+
+    if (action.packageName == EMAIL_ACTION_KEY && action.phoneNumber != null) {
+      add(Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:${Uri.encode(action.phoneNumber)}")))
+    }
+
+    if (action.dataId != null) {
+      add(
+        Intent(
+            Intent.ACTION_VIEW,
+            Uri.withAppendedPath(
+              android.provider.ContactsContract.Data.CONTENT_URI,
+              action.dataId.toString(),
+            ),
+          )
+          .setPackage(action.packageName)
+      )
+    }
+
+    if (action.packageName == WHATSAPP_PACKAGE && action.phoneNumber != null) {
+      val normalizedPhone =
+        com.searchlauncher.app.util.ContactUtils.normalizePhoneNumber(action.phoneNumber)
+      if (normalizedPhone != null) {
+        add(
+          Intent(Intent.ACTION_VIEW, Uri.parse("https://wa.me/$normalizedPhone"))
+            .setPackage(WHATSAPP_PACKAGE)
+        )
+      }
+    }
+
+    add(
+      Intent(
+          Intent.ACTION_VIEW,
+          Uri.withAppendedPath(
+            android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
+            contact.lookupKey,
+          ),
+        )
+        .setPackage(action.packageName)
+    )
+  }
+
+  /**
+   * Moves the most recently used action ([lastPackage]) to the front, preserving the relative order
+   * of the rest. A null [lastPackage] (or one not present) leaves the order unchanged.
+   */
+  internal fun orderByLastUsed(
+    actions: List<ContactChatAction>,
+    lastPackage: String?,
+  ): List<ContactChatAction> =
+    if (lastPackage == null) actions
+    else actions.sortedBy { if (it.packageName == lastPackage) 0 else 1 }
 
   internal fun chatPackageFromMimeType(mimeType: String): String? =
     KNOWN_CHAT_PACKAGES.firstOrNull { packageName ->
@@ -250,10 +265,10 @@ class ContactActionsRepository(private val context: Context) {
   }
 
   companion object {
-    private const val CALL_ACTION_KEY = "com.searchlauncher.action.CALL_CONTACT"
-    private const val SMS_ACTION_KEY = "com.searchlauncher.action.SMS_CONTACT"
-    private const val EMAIL_ACTION_KEY = "com.searchlauncher.action.EMAIL_CONTACT"
-    private const val WHATSAPP_PACKAGE = "com.whatsapp"
+    internal const val CALL_ACTION_KEY = "com.searchlauncher.action.CALL_CONTACT"
+    internal const val SMS_ACTION_KEY = "com.searchlauncher.action.SMS_CONTACT"
+    internal const val EMAIL_ACTION_KEY = "com.searchlauncher.action.EMAIL_CONTACT"
+    internal const val WHATSAPP_PACKAGE = "com.whatsapp"
     private val KNOWN_CHAT_PACKAGES =
       setOf(
         WHATSAPP_PACKAGE,

--- a/app/src/main/java/com/searchlauncher/app/data/ContactIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ContactIndexer.kt
@@ -1,0 +1,113 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.provider.ContactsContract
+import com.searchlauncher.app.util.ContactUtils
+
+/**
+ * Builds AppSearch documents for the device's contacts.
+ *
+ * This is a pure reader: it queries the contacts provider and returns documents. Persisting them
+ * (and checking the READ_CONTACTS permission) is the caller's responsibility.
+ */
+class ContactIndexer(private val context: Context) {
+
+  /**
+   * Reads contacts (with their phone numbers and emails) and returns one document per named
+   * contact. [pauseCheck] is invoked between rows so indexing yields to active searches.
+   */
+  suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+    val contacts = mutableListOf<AppSearchDocument>()
+
+    // 1. Fetch search data (Phone numbers and Emails)
+    val searchDataMap = mutableMapOf<Long, StringBuilder>()
+    val dataCursor =
+      context.contentResolver.query(
+        ContactsContract.Data.CONTENT_URI,
+        arrayOf(
+          ContactsContract.Data.CONTACT_ID,
+          ContactsContract.Data.MIMETYPE,
+          ContactsContract.Data.DATA1,
+        ),
+        "${ContactsContract.Data.MIMETYPE} IN (?, ?)",
+        arrayOf(
+          ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE,
+          ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE,
+        ),
+        null,
+      )
+
+    dataCursor?.use {
+      val contactIdIndex = it.getColumnIndex(ContactsContract.Data.CONTACT_ID)
+      val mimeTypeIndex = it.getColumnIndex(ContactsContract.Data.MIMETYPE)
+      val dataIndex = it.getColumnIndex(ContactsContract.Data.DATA1)
+
+      while (it.moveToNext()) {
+        pauseCheck()
+        val contactId = it.getLong(contactIdIndex)
+        val mimeType = it.getString(mimeTypeIndex)
+        val data = it.getString(dataIndex)
+
+        if (data != null) {
+          val sb = searchDataMap.getOrPut(contactId) { StringBuilder() }
+          // Use space as separator for better tokenization
+          sb.append(" ").append(data)
+
+          // Normalize phone numbers and add variants (e.g. 06... for +31...)
+          if (mimeType == ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE) {
+            ContactUtils.getIndexableVariants(data).forEach { sb.append(" ").append(it) }
+          }
+        }
+      }
+    }
+
+    // 2. Fetch Contacts and merge
+    val cursor =
+      context.contentResolver.query(
+        ContactsContract.Contacts.CONTENT_URI,
+        arrayOf(
+          ContactsContract.Contacts._ID,
+          ContactsContract.Contacts.DISPLAY_NAME_PRIMARY,
+          ContactsContract.Contacts.LOOKUP_KEY,
+          ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+        ),
+        null,
+        null,
+        null,
+      )
+
+    cursor?.use {
+      val idIndex = it.getColumnIndex(ContactsContract.Contacts._ID)
+      val nameIndex = it.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)
+      val lookupIndex = it.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY)
+      val photoIndex = it.getColumnIndex(ContactsContract.Contacts.PHOTO_THUMBNAIL_URI)
+
+      while (it.moveToNext()) {
+        pauseCheck()
+        val id = it.getLong(idIndex)
+        val name = it.getString(nameIndex)
+        val lookupKey = it.getString(lookupIndex)
+        val photoUri = it.getString(photoIndex)
+
+        if (name != null) {
+          val extraData = searchDataMap[id]?.toString() ?: ""
+          // Store photoUri + delimiter + searchable text
+          val description = "${photoUri ?: ""}|$extraData"
+
+          contacts.add(
+            AppSearchDocument(
+              namespace = "contacts",
+              id = "$lookupKey/$id",
+              name = name,
+              description = description,
+              score = 4,
+              intentUri = "content://com.android.contacts/contacts/lookup/$lookupKey/$id",
+            )
+          )
+        }
+      }
+    }
+
+    return contacts
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
@@ -8,7 +8,7 @@ import org.json.JSONArray
 
 class FavoritesRepository(context: Context) {
   private val prefs: SharedPreferences =
-    context.getSharedPreferences("favorites", Context.MODE_PRIVATE)
+    context.getSharedPreferences(Prefs.Favorites.FILE, Context.MODE_PRIVATE)
 
   private val _favoriteIds = MutableStateFlow<List<String>>(emptyList())
   val favoriteIds: StateFlow<List<String>> = _favoriteIds
@@ -19,7 +19,7 @@ class FavoritesRepository(context: Context) {
 
   private fun loadFavorites() {
     // Try to load the ordered JSON list first
-    val jsonString = prefs.getString("favorite_ids_ordered", null)
+    val jsonString = prefs.getString(Prefs.Favorites.IDS_ORDERED, null)
     if (jsonString != null) {
       try {
         val array = JSONArray(jsonString)
@@ -35,7 +35,7 @@ class FavoritesRepository(context: Context) {
     }
 
     // Migration path: load from the old Set if JSON is missing
-    val favoritesSet = prefs.getStringSet("favorite_ids", emptySet()) ?: emptySet()
+    val favoritesSet = prefs.getStringSet(Prefs.Favorites.IDS, emptySet()) ?: emptySet()
     _favoriteIds.value = favoritesSet.toList()
   }
 
@@ -57,9 +57,9 @@ class FavoritesRepository(context: Context) {
   private fun saveFavorites(favorites: List<String>) {
     val array = JSONArray()
     favorites.forEach { array.put(it) }
-    prefs.edit().putString("favorite_ids_ordered", array.toString()).apply()
+    prefs.edit().putString(Prefs.Favorites.IDS_ORDERED, array.toString()).apply()
     // Also update the old Set for backward compatibility or simple lookups
-    prefs.edit().putStringSet("favorite_ids", favorites.toSet()).apply()
+    prefs.edit().putStringSet(Prefs.Favorites.IDS, favorites.toSet()).apply()
   }
 
   fun updateOrder(newOrder: List<String>) {
@@ -78,6 +78,6 @@ class FavoritesRepository(context: Context) {
 
   fun clear() {
     _favoriteIds.value = emptyList()
-    prefs.edit().remove("favorite_ids_ordered").remove("favorite_ids").apply()
+    prefs.edit().remove(Prefs.Favorites.IDS_ORDERED).remove(Prefs.Favorites.IDS).apply()
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/data/HistoryRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/HistoryRepository.kt
@@ -8,7 +8,7 @@ import org.json.JSONArray
 
 class HistoryRepository(context: Context) {
   private val prefs: SharedPreferences =
-    context.getSharedPreferences("history", Context.MODE_PRIVATE)
+    context.getSharedPreferences(Prefs.History.FILE, Context.MODE_PRIVATE)
 
   private val _historyIds = MutableStateFlow<List<String>>(emptyList())
   val historyIds: StateFlow<List<String>> = _historyIds
@@ -18,7 +18,7 @@ class HistoryRepository(context: Context) {
   }
 
   private fun loadHistory() {
-    val jsonString = prefs.getString("history_ids", null)
+    val jsonString = prefs.getString(Prefs.History.IDS, null)
     if (jsonString != null) {
       try {
         val array = JSONArray(jsonString)
@@ -58,11 +58,11 @@ class HistoryRepository(context: Context) {
   private fun saveHistory(history: List<String>) {
     val array = JSONArray()
     history.forEach { array.put(it) }
-    prefs.edit().putString("history_ids", array.toString()).apply()
+    prefs.edit().putString(Prefs.History.IDS, array.toString()).apply()
   }
 
   fun clearHistory() {
     _historyIds.value = emptyList()
-    prefs.edit().remove("history_ids").apply()
+    prefs.edit().remove(Prefs.History.IDS).apply()
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
@@ -1,0 +1,108 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.LruCache
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class IconRepository(private val context: Context) {
+  private val memoryCache =
+    object : LruCache<String, Drawable>(ICON_CACHE_MAX_KB) {
+      override fun sizeOf(key: String, value: Drawable): Int {
+        val bitmap = (value as? BitmapDrawable)?.bitmap
+        if (bitmap != null && !bitmap.isRecycled) {
+          return (bitmap.allocationByteCount / 1024).coerceAtLeast(1)
+        }
+
+        val width = value.intrinsicWidth.takeIf { it > 0 } ?: ICON_SIZE_PX
+        val height = value.intrinsicHeight.takeIf { it > 0 } ?: ICON_SIZE_PX
+        return (width * height * 4 / 1024).coerceAtLeast(1)
+      }
+    }
+
+  fun getMemory(key: String): Drawable? = memoryCache.get(key)
+
+  fun putMemory(key: String, icon: Drawable) {
+    memoryCache.put(key, icon)
+  }
+
+  fun clearMemory() {
+    memoryCache.evictAll()
+  }
+
+  fun hasOnDisk(id: String): Boolean = File(getIconDir(), "${sanitizeId(id)}.png").exists()
+
+  fun saveToDisk(id: String, drawable: Drawable?, force: Boolean = true) {
+    if (drawable == null || !force) return
+    val targetFile = File(getIconDir(), "${sanitizeId(id)}.png")
+    val tmpFile = File(getIconDir(), "${sanitizeId(id)}.tmp")
+
+    try {
+      val bitmap = Bitmap.createBitmap(ICON_SIZE_PX, ICON_SIZE_PX, Bitmap.Config.ARGB_8888)
+      val canvas = Canvas(bitmap)
+      drawable.setBounds(0, 0, canvas.width, canvas.height)
+      drawable.draw(canvas)
+
+      FileOutputStream(tmpFile).use { out ->
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        out.flush()
+      }
+      bitmap.recycle()
+
+      if (tmpFile.exists() && tmpFile.length() > 0) {
+        if (targetFile.exists()) {
+          targetFile.delete()
+        }
+        tmpFile.renameTo(targetFile)
+      }
+    } catch (e: Exception) {
+      e.printStackTrace()
+      tmpFile.delete()
+    }
+  }
+
+  fun loadFromDisk(id: String): Drawable? {
+    val file = File(getIconDir(), "${sanitizeId(id)}.png")
+    if (!file.exists()) return null
+    return try {
+      val bitmap = BitmapFactory.decodeFile(file.absolutePath)
+      BitmapDrawable(context.resources, bitmap)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  suspend fun cacheAppIcon(packageName: String, customKey: String? = null) =
+    withContext(Dispatchers.IO) {
+      try {
+        val key = customKey ?: "appicon_$packageName"
+        val icon = context.packageManager.getApplicationIcon(packageName)
+        putMemory(key, icon)
+        saveToDisk(key, icon, force = true)
+        android.util.Log.d("IconRepository", "Cached icon for $packageName as $key")
+      } catch (e: Exception) {
+        android.util.Log.e("IconRepository", "Failed to cache icon for $packageName", e)
+      }
+    }
+
+  fun clearDisk() {
+    getIconDir().deleteRecursively()
+    getIconDir().mkdirs()
+  }
+
+  private fun getIconDir() = File(context.filesDir, "favorite_icons").apply { mkdirs() }
+
+  private fun sanitizeId(id: String) = id.replace("/", "_").replace(":", "_")
+
+  companion object {
+    private const val ICON_SIZE_PX = 192
+    private const val ICON_CACHE_MAX_KB = 24 * 1024
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -1,0 +1,77 @@
+package com.searchlauncher.app.data
+
+/**
+ * Central registry of the launcher's `SharedPreferences` files and their keys.
+ *
+ * Async, user-facing settings live in DataStore (see
+ * [com.searchlauncher.app.ui.PreferencesKeys]); this object covers the remaining
+ * `SharedPreferences`-backed state — per-store, so it's clear which file owns which value.
+ *
+ * IMPORTANT: every string here names data persisted on users' devices. Changing a value orphans
+ * existing data, so treat these constants as immutable; add new ones rather than renaming.
+ */
+object Prefs {
+
+  /** Privacy/consent flags, written before any DataStore access. */
+  object Privacy {
+    const val FILE = "privacy_prefs"
+    const val CONSENT_GRANTED = "consent_granted"
+    const val ASKED_DEFAULT_LAUNCHER = "asked_default_launcher"
+  }
+
+  /** The in-flight query, persisted so it can be restored across short app exits. */
+  object ActiveSearch {
+    const val FILE = "active_search"
+    const val QUERY = "active_query"
+    const val QUERY_TIME = "active_query_time"
+  }
+
+  /**
+   * Miscellaneous launcher state.
+   *
+   * Note: [MIN_ICON_SIZE] mirrors the DataStore setting of the same name; it is kept here only as a
+   * synchronous boot cache so the first frame can size icons without waiting on DataStore.
+   */
+  object Launcher {
+    const val FILE = "search_launcher_prefs"
+    const val MIN_ICON_SIZE = "min_icon_size"
+    const val OBSERVED_HISTORY_LIMIT = "observed_history_limit"
+    const val LAST_REINDEX_TIMESTAMP = "last_reindex_timestamp"
+  }
+
+  /** Measured soft-keyboard height, cached to avoid layout jump on the next launch. */
+  object Window {
+    const val FILE = "window_prefs"
+    const val KEYBOARD_HEIGHT = "keyboard_height"
+  }
+
+  /** Pinned favorites (ordered list plus a legacy unordered set). */
+  object Favorites {
+    const val FILE = "favorites"
+    const val IDS_ORDERED = "favorite_ids_ordered"
+    const val IDS = "favorite_ids"
+  }
+
+  /** User-defined search shortcuts, stored as a JSON array. */
+  object SearchShortcuts {
+    const val FILE = "search_shortcuts"
+    const val SHORTCUTS = "shortcuts"
+  }
+
+  /** Quick-copy text snippets, stored as a JSON array. */
+  object Snippets {
+    const val FILE = "quick_copy"
+    const val ITEMS = "items"
+  }
+
+  /** Recently used result ids, stored as a JSON array. */
+  object History {
+    const val FILE = "history"
+    const val IDS = "history_ids"
+  }
+
+  /** Last-used chat app per contact (keys are contact ids, so no fixed key names). */
+  object ContactActions {
+    const val FILE = "contact_chat_actions"
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/Prefs.kt
@@ -3,9 +3,9 @@ package com.searchlauncher.app.data
 /**
  * Central registry of the launcher's `SharedPreferences` files and their keys.
  *
- * Async, user-facing settings live in DataStore (see
- * [com.searchlauncher.app.ui.PreferencesKeys]); this object covers the remaining
- * `SharedPreferences`-backed state — per-store, so it's clear which file owns which value.
+ * Async, user-facing settings live in DataStore (see [com.searchlauncher.app.ui.PreferencesKeys]);
+ * this object covers the remaining `SharedPreferences`-backed state — per-store, so it's clear
+ * which file owns which value.
  *
  * IMPORTANT: every string here names data persisted on users' devices. Changing a value orphans
  * existing data, so treat these constants as immutable; add new ones rather than renaming.

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRanker.kt
@@ -1,0 +1,214 @@
+package com.searchlauncher.app.data
+
+import com.searchlauncher.app.util.ContactUtils
+import com.searchlauncher.app.util.FuzzyMatch
+
+object SearchRanker {
+  fun rankCandidates(
+    query: String,
+    snapshot: List<SearchableDocument>,
+    includeSearchShortcuts: Boolean,
+    usageStats: Map<String, Int>,
+    queryUsageStats: Map<String, Int>,
+    documentByNamespaceAndId: Map<String, SearchableDocument>,
+  ): List<Pair<SearchableDocument, Int>> {
+    val candidates = mutableListOf<Pair<SearchableDocument, Int>>()
+    val queryLower = query.lowercase().trim()
+    val usageQuery = normalizedUsageQuery(queryLower)
+    val queryMask = calculateCharMask(queryLower)
+    val normalizedQuery = ContactUtils.normalizePhoneNumber(queryLower)
+
+    for (sdoc in snapshot) {
+      if (!includeSearchShortcuts && sdoc.namespaceInt == 7) continue
+
+      val fuzzyScore =
+        FuzzyMatch.calculateScore(
+          queryLower,
+          sdoc.nameLower,
+          sdoc.targetWords,
+          sdoc.acronym,
+          queryMask,
+          sdoc.charMask,
+        )
+
+      val contactScore =
+        if (
+          sdoc.namespaceInt == 5 &&
+            normalizedQuery != null &&
+            normalizedQuery.length >= RankingScores.CONTACT_STRONG_MATCH_MIN_QUERY_LENGTH &&
+            sdoc.normalizedPhone?.contains(normalizedQuery) == true
+        ) {
+          RankingScores.CONTACT_PHONE_MATCH_SCORE
+        } else {
+          0
+        }
+
+      val finalScore = maxOf(fuzzyScore, contactScore)
+      if (finalScore > RankingScores.MIN_CANDIDATE_SCORE) {
+        val doc = sdoc.doc
+        val globalUsage = getGlobalUsageCount(usageStats, doc.namespace, doc.id)
+        val queryUsagePoints =
+          getQueryUsagePoints(queryUsageStats, usageQuery, doc.namespace, doc.id)
+        val namespaceBoost = namespaceBoost(sdoc, queryLower, finalScore, queryUsagePoints)
+        val usageBoost = usageBoost(globalUsage, queryUsagePoints)
+
+        candidates.add(sdoc to (finalScore + namespaceBoost + usageBoost))
+      }
+
+      if (candidates.size > MAX_CANDIDATES) break
+    }
+
+    addLearnedShortQueryContacts(
+      queryLower = queryLower,
+      usageQuery = usageQuery,
+      queryMask = queryMask,
+      candidates = candidates,
+      usageStats = usageStats,
+      queryUsageStats = queryUsageStats,
+      documentByNamespaceAndId = documentByNamespaceAndId,
+    )
+
+    return candidates.sortedByDescending { it.second }
+  }
+
+  fun calculateCharMask(text: String): Long {
+    var mask = 0L
+    for (c in text) {
+      if (c in 'a'..'z') mask = mask or (1L shl (c - 'a'))
+      else if (c in '0'..'9') mask = mask or (1L shl (c - '0' + 26))
+    }
+    return mask
+  }
+
+  private fun namespaceBoost(
+    sdoc: SearchableDocument,
+    queryLower: String,
+    finalScore: Int,
+    queryUsagePoints: Int,
+  ): Int {
+    var boost =
+      when (sdoc.namespaceInt) {
+        1 -> RankingScores.NAMESPACE_BOOST_APPS
+        2 -> RankingScores.NAMESPACE_BOOST_APP_SHORTCUTS
+        3 -> RankingScores.NAMESPACE_BOOST_WEB_BOOKMARKS
+        4 -> RankingScores.NAMESPACE_BOOST_SHORTCUTS
+        5 -> RankingScores.NAMESPACE_BOOST_CONTACTS
+        8 -> RankingScores.NAMESPACE_BOOST_SNIPPETS
+        else -> RankingScores.NAMESPACE_BOOST_DEFAULT
+      }
+
+    if (queryLower.length <= RankingScores.SHORT_QUERY_MAX_LENGTH && sdoc.namespaceInt <= 2) {
+      boost += RankingScores.SHORT_QUERY_APP_BOOST
+    }
+
+    if (
+      sdoc.namespaceInt == 5 &&
+        queryLower.length >= RankingScores.CONTACT_STRONG_MATCH_MIN_QUERY_LENGTH &&
+        finalScore >= RankingScores.CONTACT_PHONE_MATCH_SCORE
+    ) {
+      boost += RankingScores.CONTACT_STRONG_MATCH_BOOST
+    }
+
+    if (
+      sdoc.namespaceInt == 5 &&
+        queryLower.length <= RankingScores.LEARNED_CONTACT_SHORT_QUERY_MAX_LENGTH &&
+        queryUsagePoints > 0 &&
+        finalScore >= RankingScores.CONTACT_PHONE_MATCH_SCORE
+    ) {
+      boost += RankingScores.LEARNED_CONTACT_SHORT_QUERY_BOOST
+    }
+
+    return boost
+  }
+
+  private fun addLearnedShortQueryContacts(
+    queryLower: String,
+    usageQuery: String?,
+    queryMask: Long,
+    candidates: MutableList<Pair<SearchableDocument, Int>>,
+    usageStats: Map<String, Int>,
+    queryUsageStats: Map<String, Int>,
+    documentByNamespaceAndId: Map<String, SearchableDocument>,
+  ) {
+    if (
+      usageQuery == null || queryLower.length > RankingScores.LEARNED_CONTACT_SHORT_QUERY_MAX_LENGTH
+    )
+      return
+
+    val existingContactIds =
+      candidates.asSequence().filter { it.first.namespaceInt == 5 }.map { it.first.doc.id }.toSet()
+    val keyPrefix = queryUsageKeyPrefix(usageQuery, "contacts")
+    val learnedContactEntries =
+      queryUsageStats.entries
+        .asSequence()
+        .filter { (key, points) -> points > 0 && key.startsWith(keyPrefix) }
+        .sortedByDescending { it.value }
+        .take(LEARNED_CONTACT_ENTRY_LIMIT)
+        .toList()
+
+    for ((key, queryUsagePoints) in learnedContactEntries) {
+      val contactId = key.removePrefix(keyPrefix)
+      if (contactId in existingContactIds) continue
+      val sdoc = documentByNamespaceAndId[documentLookupKey("contacts", contactId)] ?: continue
+      val finalScore =
+        FuzzyMatch.calculateScore(
+          queryLower,
+          sdoc.nameLower,
+          sdoc.targetWords,
+          sdoc.acronym,
+          queryMask,
+          sdoc.charMask,
+        )
+      if (finalScore < RankingScores.CONTACT_PHONE_MATCH_SCORE) continue
+
+      val doc = sdoc.doc
+      val globalUsage = getGlobalUsageCount(usageStats, doc.namespace, doc.id)
+      val usageBoost = usageBoost(globalUsage, queryUsagePoints)
+
+      candidates.add(
+        sdoc to
+          (finalScore +
+            RankingScores.NAMESPACE_BOOST_CONTACTS +
+            RankingScores.LEARNED_CONTACT_SHORT_QUERY_BOOST +
+            usageBoost)
+      )
+    }
+  }
+
+  private fun usageBoost(globalUsage: Int, queryUsagePoints: Int): Int =
+    (globalUsage.coerceAtMost(RankingScores.GLOBAL_USAGE_SCORE_CAP) *
+      RankingScores.GLOBAL_USAGE_SCORE_BOOST) +
+      (queryUsagePoints.coerceAtMost(RankingScores.QUERY_USAGE_POINTS_CAP) *
+        RankingScores.QUERY_USAGE_POINT_SCORE_BOOST)
+
+  private fun getGlobalUsageCount(
+    usageStats: Map<String, Int>,
+    namespace: String,
+    id: String,
+  ): Int = usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
+
+  private fun getQueryUsagePoints(
+    queryUsageStats: Map<String, Int>,
+    query: String?,
+    namespace: String,
+    id: String,
+  ): Int = query?.let { queryUsageStats[queryUsageKey(it, namespace, id)] } ?: 0
+
+  private fun normalizedUsageQuery(query: String?): String? =
+    query?.trim()?.lowercase()?.replace(Regex("\\s+"), " ")?.takeIf { it.isNotEmpty() }
+
+  private fun documentLookupKey(namespace: String, id: String): String =
+    "$namespace$USAGE_KEY_SEPARATOR$id"
+
+  private fun usageKey(namespace: String, id: String): String = "$namespace$USAGE_KEY_SEPARATOR$id"
+
+  private fun queryUsageKeyPrefix(query: String, namespace: String): String =
+    "$query$USAGE_KEY_SEPARATOR$namespace$USAGE_KEY_SEPARATOR"
+
+  private fun queryUsageKey(query: String, namespace: String, id: String): String =
+    "${queryUsageKeyPrefix(query, namespace)}$id"
+
+  private const val USAGE_KEY_SEPARATOR = "\u001F"
+  private const val MAX_CANDIDATES = 1000
+  private const val LEARNED_CONTACT_ENTRY_LIMIT = 8
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -2,15 +2,8 @@ package com.searchlauncher.app.data
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.net.Uri
 import android.util.Log
-import android.util.LruCache
 import androidx.appsearch.app.AppSearchSession
 import androidx.appsearch.app.PutDocumentsRequest
 import androidx.appsearch.app.RemoveByDocumentIdRequest
@@ -22,13 +15,11 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.dataStore
-import com.searchlauncher.app.util.FuzzyMatch
 import com.searchlauncher.app.util.StaticShortcutScanner
 import com.searchlauncher.app.util.SystemUtils
 import com.searchlauncher.app.util.traceSection
 import io.sentry.Sentry
 import java.io.File
-import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.Executors
@@ -84,19 +75,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private var appSearchSession: AppSearchSession? = null
   @Volatile private var pauseIndexingUntilMs: Long = 0L
 
-  private val defaultContactIcon: Drawable by lazy {
-    context.getDrawable(com.searchlauncher.app.R.drawable.ic_contact_default)!!.apply {
-      setTint(Color.GRAY)
-    }
-  }
-
   private fun calculateCharMask(text: String): Long {
-    var mask = 0L
-    for (c in text) {
-      if (c in 'a'..'z') mask = mask or (1L shl (c - 'a'))
-      else if (c in '0'..'9') mask = mask or (1L shl (c - '0' + 26))
-    }
-    return mask
+    return SearchRanker.calculateCharMask(text)
   }
 
   internal fun wrap(doc: AppSearchDocument): SearchableDocument {
@@ -192,20 +172,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   private val executor = Executors.newSingleThreadExecutor()
   private val smartActionManager = SmartActionManager(context)
+  private val contactActionsRepository = ContactActionsRepository(context)
   private val iconGenerator = SearchIconGenerator(context)
-  private val iconCache =
-    object : LruCache<String, Drawable>(ICON_CACHE_MAX_KB) {
-      override fun sizeOf(key: String, value: Drawable): Int {
-        val bitmap = (value as? BitmapDrawable)?.bitmap
-        if (bitmap != null && !bitmap.isRecycled) {
-          return (bitmap.allocationByteCount / 1024).coerceAtLeast(1)
-        }
-
-        val width = value.intrinsicWidth.takeIf { it > 0 } ?: ICON_SIZE_PX
-        val height = value.intrinsicHeight.takeIf { it > 0 } ?: ICON_SIZE_PX
-        return (width * height * 4 / 1024).coerceAtLeast(1)
-      }
-    }
+  private val iconRepository = IconRepository(context)
+  private val searchResultFactory = SearchResultFactory(context, iconRepository, iconGenerator)
 
   private val _isInitialized = kotlinx.coroutines.flow.MutableStateFlow(false)
   val isInitialized: kotlinx.coroutines.flow.StateFlow<Boolean> = _isInitialized
@@ -253,182 +223,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private val queryUsageStats = java.util.concurrent.ConcurrentHashMap<String, Int>()
 
   suspend fun getContactChatActions(contact: SearchResult.Contact): List<ContactChatAction> =
-    withContext(Dispatchers.IO) {
-      val permission = context.checkSelfPermission(android.Manifest.permission.READ_CONTACTS)
-      if (permission != android.content.pm.PackageManager.PERMISSION_GRANTED) {
-        return@withContext emptyList()
-      }
+    contactActionsRepository.getContactActions(contact)
 
-      val actionsByPackage = linkedMapOf<String, ContactChatAction>()
-      val dataCursor =
-        context.contentResolver.query(
-          android.provider.ContactsContract.Data.CONTENT_URI,
-          arrayOf(
-            android.provider.ContactsContract.Data._ID,
-            android.provider.ContactsContract.Data.MIMETYPE,
-            android.provider.ContactsContract.Data.DATA1,
-          ),
-          "${android.provider.ContactsContract.Data.CONTACT_ID} = ?",
-          arrayOf(contact.contactId.toString()),
-          null,
-        )
-
-      dataCursor?.use {
-        val idIndex = it.getColumnIndex(android.provider.ContactsContract.Data._ID)
-        val mimeIndex = it.getColumnIndex(android.provider.ContactsContract.Data.MIMETYPE)
-        val data1Index = it.getColumnIndex(android.provider.ContactsContract.Data.DATA1)
-        while (it.moveToNext()) {
-          val mimeType = it.getString(mimeIndex) ?: continue
-          val packageName = chatPackageFromMimeType(mimeType) ?: continue
-          if (!isPackageInstalled(packageName)) continue
-          actionsByPackage.putIfAbsent(
-            packageName,
-            ContactChatAction(
-              label = getApplicationLabel(packageName) ?: packageName,
-              packageName = packageName,
-              dataId = it.getLong(idIndex),
-              phoneNumber = it.getString(data1Index),
-              icon = getApplicationIcon(packageName),
-            ),
-          )
-        }
-      }
-
-      val phoneNumber = getPrimaryPhoneNumber(contact.contactId)
-      if (phoneNumber != null && isPackageInstalled(WHATSAPP_PACKAGE)) {
-        actionsByPackage.putIfAbsent(
-          WHATSAPP_PACKAGE,
-          ContactChatAction(
-            label = getApplicationLabel(WHATSAPP_PACKAGE) ?: "WhatsApp",
-            packageName = WHATSAPP_PACKAGE,
-            phoneNumber = phoneNumber,
-            icon = getApplicationIcon(WHATSAPP_PACKAGE),
-          ),
-        )
-      }
-      if (phoneNumber != null) {
-        actionsByPackage.putIfAbsent(
-          SMS_ACTION_KEY,
-          ContactChatAction(
-            label = "SMS",
-            packageName = SMS_ACTION_KEY,
-            phoneNumber = phoneNumber,
-            icon = context.getDrawable(android.R.drawable.sym_action_chat),
-          ),
-        )
-        actionsByPackage.putIfAbsent(
-          CALL_ACTION_KEY,
-          ContactChatAction(
-            label = "Call",
-            packageName = CALL_ACTION_KEY,
-            phoneNumber = phoneNumber,
-            icon = context.getDrawable(android.R.drawable.ic_menu_call),
-          ),
-        )
-      }
-      val emailAddress = getPrimaryEmailAddress(contact.contactId)
-      if (emailAddress != null) {
-        actionsByPackage.putIfAbsent(
-          EMAIL_ACTION_KEY,
-          ContactChatAction(
-            label = "Email",
-            packageName = EMAIL_ACTION_KEY,
-            phoneNumber = emailAddress,
-            icon = context.getDrawable(android.R.drawable.ic_dialog_email),
-          ),
-        )
-      }
-
-      val actions = actionsByPackage.values.toList()
-      val lastPackage = getLastContactChatPackage(contact.id)
-      if (lastPackage == null) {
-        actions
-      } else {
-        actions.sortedBy { if (it.packageName == lastPackage) 0 else 1 }
-      }
-    }
-
-  fun launchContactChatAction(contact: SearchResult.Contact, action: ContactChatAction): Boolean {
-    val intents = buildList {
-      if (action.packageName == CALL_ACTION_KEY && action.phoneNumber != null) {
-        add(
-          android.content.Intent(
-            android.content.Intent.ACTION_DIAL,
-            Uri.parse("tel:${Uri.encode(action.phoneNumber)}"),
-          )
-        )
-      }
-
-      if (action.packageName == SMS_ACTION_KEY && action.phoneNumber != null) {
-        add(
-          android.content.Intent(
-            android.content.Intent.ACTION_SENDTO,
-            Uri.parse("smsto:${Uri.encode(action.phoneNumber)}"),
-          )
-        )
-      }
-
-      if (action.packageName == EMAIL_ACTION_KEY && action.phoneNumber != null) {
-        add(
-          android.content.Intent(
-            android.content.Intent.ACTION_SENDTO,
-            Uri.parse("mailto:${Uri.encode(action.phoneNumber)}"),
-          )
-        )
-      }
-
-      if (action.dataId != null) {
-        add(
-          android.content.Intent(
-              android.content.Intent.ACTION_VIEW,
-              Uri.withAppendedPath(
-                android.provider.ContactsContract.Data.CONTENT_URI,
-                action.dataId.toString(),
-              ),
-            )
-            .setPackage(action.packageName)
-        )
-      }
-
-      if (action.packageName == WHATSAPP_PACKAGE && action.phoneNumber != null) {
-        val normalizedPhone = com.searchlauncher.app.util.ContactUtils.normalizePhoneNumber(
-          action.phoneNumber
-        )
-        if (normalizedPhone != null) {
-          add(
-            android.content.Intent(
-                android.content.Intent.ACTION_VIEW,
-                Uri.parse("https://wa.me/$normalizedPhone"),
-              )
-              .setPackage(WHATSAPP_PACKAGE)
-          )
-        }
-      }
-
-      add(
-        android.content.Intent(
-            android.content.Intent.ACTION_VIEW,
-            Uri.withAppendedPath(
-              android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
-              contact.lookupKey,
-            ),
-          )
-          .setPackage(action.packageName)
-      )
-    }
-
-    for (intent in intents) {
-      try {
-        intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-        setLastContactChatPackage(contact.id, action.packageName)
-        return true
-      } catch (e: Exception) {
-        // Try the next route.
-      }
-    }
-    return false
-  }
+  fun launchContactChatAction(contact: SearchResult.Contact, action: ContactChatAction): Boolean =
+    contactActionsRepository.launchContactAction(contact, action)
 
   suspend fun initialize(): Result<Unit> =
     safeCall("SearchRepository", "Error initializing") {
@@ -460,7 +258,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           // Pre-cache SearchLauncher's own icon for internal actions
           scope.launch {
             try {
-              cacheAppIcon(context.packageName, "launcher_app_icon")
+              iconRepository.cacheAppIcon(context.packageName, "launcher_app_icon")
             } catch (e: Exception) {
               e.printStackTrace()
             }
@@ -933,17 +731,17 @@ class SearchRepository(private val context: Context) : BaseRepository() {
                       context.resources.displayMetrics.densityDpi,
                     )
                   if (icon != null) {
-                    saveIconToDisk("shortcut_$shortcutId", icon, force = true)
+                    iconRepository.saveToDisk("shortcut_$shortcutId", icon, force = true)
                   }
                 } catch (e: Exception) {
                   // Ignore icon loading failures
                 }
 
                 val pkg = shortcut.`package`
-                if (!hasIconOnDisk("appicon_$pkg")) {
+                if (!iconRepository.hasOnDisk("appicon_$pkg")) {
                   try {
                     val appIcon = context.packageManager.getApplicationIcon(pkg)
-                    saveIconToDisk("appicon_$pkg", appIcon, force = true)
+                    iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
                   } catch (e: Exception) {
                     // Ignore icon loading failures
                   }
@@ -1084,7 +882,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             val res = context.packageManager.getResourcesForApplication(s.packageName)
             val icon = res.getDrawable(s.iconResId.toInt(), null)
             if (icon != null) {
-              saveIconToDisk("static_shortcut_$shortcutId", icon, force = true)
+              iconRepository.saveToDisk("static_shortcut_$shortcutId", icon, force = true)
             }
           }
         } catch (e: Exception) {
@@ -1093,10 +891,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         }
 
         // Pre-load and cache app icon
-        if (!hasIconOnDisk("appicon_${s.packageName}")) {
+        if (!iconRepository.hasOnDisk("appicon_${s.packageName}")) {
           try {
             val appIcon = context.packageManager.getApplicationIcon(s.packageName)
-            saveIconToDisk("appicon_${s.packageName}", appIcon, force = true)
+            iconRepository.saveToDisk("appicon_${s.packageName}", appIcon, force = true)
           } catch (e: Exception) {
             // Ignore app icon loading failures
             Sentry.captureException(e)
@@ -1666,7 +1464,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         android.util.Log.d("SearchRepository", "onPackageAdded: $packageName")
         scope.launch {
           indexApps()
-          cacheAppIcon(packageName)
+          iconRepository.cacheAppIcon(packageName)
           _packageUpdated.emit(null) // null means generic update
         }
       }
@@ -1674,7 +1472,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       override fun onPackageChanged(packageName: String, user: android.os.UserHandle) {
         scope.launch {
           indexApps()
-          cacheAppIcon(packageName)
+          iconRepository.cacheAppIcon(packageName)
           _packageUpdated.emit(null)
         }
       }
@@ -2060,107 +1858,23 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     includeSearchShortcuts: Boolean,
   ): List<SearchResult> {
     val startTime = System.currentTimeMillis()
-    val candidates = mutableListOf<Pair<SearchableDocument, Int>>()
-
-    val queryLower = query.lowercase().trim()
-    val usageQuery = normalizedUsageQuery(queryLower)
-    val queryMask = calculateCharMask(queryLower)
-    val normalizedQuery = com.searchlauncher.app.util.ContactUtils.normalizePhoneNumber(queryLower)
 
     val snapshot = documentSnapshot
-    val syncStart = System.currentTimeMillis()
-    traceSection("SL:SearchRepository.scanSnapshot") {
-      for (sdoc in snapshot) {
-        if (!includeSearchShortcuts && sdoc.namespaceInt == 7) continue
-
-        val score =
-          FuzzyMatch.calculateScore(
-            queryLower,
-            sdoc.nameLower,
-            sdoc.targetWords,
-            sdoc.acronym,
-            queryMask,
-            sdoc.charMask,
-          )
-
-        // Also check normalized phone number for contacts (use pre-computed normalizedPhone)
-        var contactScore = 0
-        if (
-          sdoc.namespaceInt == 5 &&
-            normalizedQuery != null &&
-            normalizedQuery.length >= RankingScores.CONTACT_STRONG_MATCH_MIN_QUERY_LENGTH
-        ) {
-          if (sdoc.normalizedPhone?.contains(normalizedQuery) == true) {
-            contactScore = RankingScores.CONTACT_PHONE_MATCH_SCORE
-          }
-        }
-
-        val finalScore = maxOf(score, contactScore)
-        if (finalScore > RankingScores.MIN_CANDIDATE_SCORE) {
-          val doc = sdoc.doc
-          val globalUsage = getGlobalUsageCount(doc.namespace, doc.id)
-          val queryUsagePoints = getQueryUsagePoints(usageQuery, doc.namespace, doc.id)
-          var namespaceBoost =
-            when (sdoc.namespaceInt) {
-              1 -> RankingScores.NAMESPACE_BOOST_APPS
-              2 -> RankingScores.NAMESPACE_BOOST_APP_SHORTCUTS
-              3 -> RankingScores.NAMESPACE_BOOST_WEB_BOOKMARKS
-              4 -> RankingScores.NAMESPACE_BOOST_SHORTCUTS
-              5 -> RankingScores.NAMESPACE_BOOST_CONTACTS
-              8 -> RankingScores.NAMESPACE_BOOST_SNIPPETS
-              else -> RankingScores.NAMESPACE_BOOST_DEFAULT
-            }
-
-          // Extra boost for apps / app_shortcuts on very short (1-2 char) queries.
-          if (queryLower.length <= RankingScores.SHORT_QUERY_MAX_LENGTH && sdoc.namespaceInt <= 2) {
-            namespaceBoost += RankingScores.SHORT_QUERY_APP_BOOST
-          }
-
-          if (
-            sdoc.namespaceInt == 5 &&
-              queryLower.length >= RankingScores.CONTACT_STRONG_MATCH_MIN_QUERY_LENGTH &&
-              finalScore >= RankingScores.CONTACT_PHONE_MATCH_SCORE
-          ) {
-            namespaceBoost += RankingScores.CONTACT_STRONG_MATCH_BOOST
-          }
-
-          if (
-            sdoc.namespaceInt == 5 &&
-              queryLower.length <= RankingScores.LEARNED_CONTACT_SHORT_QUERY_MAX_LENGTH &&
-              queryUsagePoints > 0 &&
-              finalScore >= RankingScores.CONTACT_PHONE_MATCH_SCORE
-          ) {
-            namespaceBoost += RankingScores.LEARNED_CONTACT_SHORT_QUERY_BOOST
-          }
-
-          val usageBoost =
-            (globalUsage.coerceAtMost(RankingScores.GLOBAL_USAGE_SCORE_CAP) *
-              RankingScores.GLOBAL_USAGE_SCORE_BOOST) +
-              (queryUsagePoints.coerceAtMost(RankingScores.QUERY_USAGE_POINTS_CAP) *
-                RankingScores.QUERY_USAGE_POINT_SCORE_BOOST)
-
-          candidates.add(sdoc to (finalScore + namespaceBoost + usageBoost))
-        }
-
-        if (candidates.size > 1000) break
+    val rankStart = System.currentTimeMillis()
+    val candidates =
+      traceSection("SL:SearchRepository.rankCandidates") {
+        SearchRanker.rankCandidates(
+          query = query,
+          snapshot = snapshot,
+          includeSearchShortcuts = includeSearchShortcuts,
+          usageStats = usageStats,
+          queryUsageStats = queryUsageStats,
+          documentByNamespaceAndId = documentByNamespaceAndId,
+        )
       }
-    }
-    addLearnedShortQueryContacts(
-      queryLower = queryLower,
-      usageQuery = usageQuery,
-      queryMask = queryMask,
-      candidates = candidates,
-    )
     android.util.Log.v(
       "SearchRepository",
-      "  [Timing] scan of ${snapshot.size} docs took ${System.currentTimeMillis() - syncStart}ms",
-    )
-
-    val sortStart = System.currentTimeMillis()
-    traceSection("SL:SearchRepository.sortCandidates") { candidates.sortByDescending { it.second } }
-    android.util.Log.v(
-      "SearchRepository",
-      "  [Timing] Sorting ${candidates.size} candidates took ${System.currentTimeMillis() - sortStart}ms",
+      "  [Timing] Ranking ${snapshot.size} docs took ${System.currentTimeMillis() - rankStart}ms",
     )
 
     val appSearchResults = mutableListOf<SearchResult>()
@@ -2206,77 +1920,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     return appSearchResults
   }
 
-  private fun addLearnedShortQueryContacts(
-    queryLower: String,
-    usageQuery: String?,
-    queryMask: Long,
-    candidates: MutableList<Pair<SearchableDocument, Int>>,
-  ) {
-    if (
-      usageQuery == null || queryLower.length > RankingScores.LEARNED_CONTACT_SHORT_QUERY_MAX_LENGTH
-    )
-      return
-
-    val existingContactIds =
-      candidates.asSequence().filter { it.first.namespaceInt == 5 }.map { it.first.doc.id }.toSet()
-    val keyPrefix = queryUsageKeyPrefix(usageQuery, "contacts")
-    val learnedContactEntries =
-      queryUsageStats.entries
-        .asSequence()
-        .filter { (key, points) -> points > 0 && key.startsWith(keyPrefix) }
-        .sortedByDescending { it.value }
-        .take(8)
-        .toList()
-
-    for ((key, queryUsagePoints) in learnedContactEntries) {
-      val contactId = key.removePrefix(keyPrefix)
-      if (contactId in existingContactIds) continue
-      val sdoc = documentByNamespaceAndId[documentLookupKey("contacts", contactId)] ?: continue
-      val finalScore =
-        FuzzyMatch.calculateScore(
-          queryLower,
-          sdoc.nameLower,
-          sdoc.targetWords,
-          sdoc.acronym,
-          queryMask,
-          sdoc.charMask,
-        )
-      if (finalScore < RankingScores.CONTACT_PHONE_MATCH_SCORE) continue
-
-      val doc = sdoc.doc
-      val globalUsage = getGlobalUsageCount(doc.namespace, doc.id)
-      val usageBoost =
-        (globalUsage.coerceAtMost(RankingScores.GLOBAL_USAGE_SCORE_CAP) *
-          RankingScores.GLOBAL_USAGE_SCORE_BOOST) +
-          (queryUsagePoints.coerceAtMost(RankingScores.QUERY_USAGE_POINTS_CAP) *
-            RankingScores.QUERY_USAGE_POINT_SCORE_BOOST)
-
-      candidates.add(
-        sdoc to
-          (finalScore +
-            RankingScores.NAMESPACE_BOOST_CONTACTS +
-            RankingScores.LEARNED_CONTACT_SHORT_QUERY_BOOST +
-            usageBoost)
-      )
-    }
-  }
-
-  private fun getFuzzyMatches(query: String): List<Pair<AppSearchDocument, Int>> {
-    val results = mutableListOf<Pair<AppSearchDocument, Int>>()
-    val queryLower = query.lowercase().trim()
-    for (sdoc in documentSnapshot) {
-      val doc = sdoc.doc
-      val score =
-        FuzzyMatch.calculateScore(queryLower, sdoc.nameLower, sdoc.targetWords, sdoc.acronym)
-      if (score > 40) {
-        results.add(doc to score)
-      }
-      // Safety break if cache is somehow malformed/infinite
-      if (results.size > 500) break
-    }
-    return results.sortedByDescending { it.second }.take(50)
-  }
-
   suspend fun searchContent(): List<SearchResult.Content> =
     withContext(Dispatchers.IO) { emptyList() }
 
@@ -2319,7 +1962,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW ||
         level == android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
     ) {
-      iconCache.evictAll()
+      iconRepository.clearMemory()
       android.util.Log.d("SearchRepository", "Evicted icon cache on trim memory level $level")
     }
   }
@@ -2336,338 +1979,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     saveToDisk: Boolean = false,
     allowIpc: Boolean = true,
     allowDisk: Boolean = true,
-  ): SearchResult {
-    val doc = sdoc.doc
-    kotlinx.coroutines.currentCoroutineContext().ensureActive()
-    return when (doc.namespace) {
-      "shortcuts" -> {
-        // Icons pre-cached during indexing, just load from cache
-        var icon: Drawable? = iconCache.get("shortcut_${doc.id}")
-        if (icon == null && allowDisk) {
-          val diskIcon = loadIconFromDisk("shortcut_${doc.id}")
-          if (diskIcon != null) {
-            icon = diskIcon
-            iconCache.put("shortcut_${doc.id}", icon)
-          } else if (allowIpc) {
-            try {
-              val launcherApps =
-                context.getSystemService(Context.LAUNCHER_APPS_SERVICE)
-                  as android.content.pm.LauncherApps
-              val user = android.os.Process.myUserHandle()
-              val q = android.content.pm.LauncherApps.ShortcutQuery()
-              val packageName = sdoc.packageName ?: ""
-              val shortcutId = doc.id.substringAfter("/")
-              q.setPackage(packageName)
-              q.setShortcutIds(listOf(shortcutId))
-              q.setQueryFlags(
-                android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                  android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                  android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
-              )
-              val shortcuts = launcherApps.getShortcuts(q, user)
-              if (shortcuts != null && shortcuts.isNotEmpty()) {
-                icon =
-                  launcherApps.getShortcutIconDrawable(
-                    shortcuts[0],
-                    context.resources.displayMetrics.densityDpi,
-                  )
-                if (icon != null) {
-                  iconCache.put("shortcut_${doc.id}", icon)
-                  if (saveToDisk) {
-                    saveIconToDisk("shortcut_${doc.id}", icon, force = true)
-                  }
-                }
-              }
-            } catch (e: Exception) {
-              // Ignore
-            }
-          }
-        }
-
-        // App icons pre-cached during indexing
-        val pkg = sdoc.packageName ?: ""
-        val appIcon =
-          iconCache.get("appicon_$pkg")
-            ?: (if (allowDisk)
-              loadIconFromDisk("appicon_$pkg")?.also { iconCache.put("appicon_$pkg", it) }
-            else null)
-            ?: (if (allowIpc) {
-              try {
-                val ai = context.packageManager.getApplicationIcon(pkg)
-                iconCache.put("appicon_$pkg", ai)
-                if (saveToDisk) {
-                  saveIconToDisk("appicon_$pkg", ai, force = true)
-                }
-                ai
-              } catch (e: Exception) {
-                null
-              }
-            } else null)
-
-        SearchResult.Shortcut(
-          id = doc.id,
-          namespace = "shortcuts",
-          title = doc.name,
-          subtitle = doc.description ?: "Shortcut",
-          icon = icon,
-          packageName = pkg,
-          intentUri = doc.intentUri ?: "",
-          appIcon = appIcon,
-          rankingScore = rankingScore,
-        )
-      }
-      "app_shortcuts" -> {
-        // Check cache first (settings icons, camera icons, etc.)
-        var icon: Drawable? = iconCache.get("app_shortcut_${doc.id}")
-        if (icon == null && allowDisk) {
-          val diskIcon = loadIconFromDisk("app_shortcut_${doc.id}")
-          if (diskIcon != null) {
-            icon = diskIcon
-            iconCache.put("app_shortcut_${doc.id}", icon)
-          } else if (allowIpc) {
-            icon =
-              when {
-                doc.intentUri?.contains("android.settings") == true -> {
-                  try {
-                    context.packageManager.getApplicationIcon("com.android.settings")
-                  } catch (e: Exception) {
-                    null
-                  }
-                }
-                doc.intentUri?.contains("STILL_IMAGE_CAMERA") == true -> {
-                  context.getDrawable(android.R.drawable.ic_menu_camera)
-                }
-                doc.intentUri?.contains("VIDEO_CAMERA") == true -> {
-                  context.getDrawable(android.R.drawable.ic_menu_camera)
-                }
-                else -> null
-              }
-            if (icon != null) {
-              iconCache.put("app_shortcut_${doc.id}", icon)
-              if (saveToDisk) {
-                saveIconToDisk("app_shortcut_${doc.id}", icon, force = true)
-              }
-            }
-          }
-        }
-
-        val isLauncherItem = doc.id.contains("launcher_")
-        val launcherIcon =
-          if (isLauncherItem) {
-            // Launcher icon should be pre-cached
-            val cacheKey = "launcher_app_icon"
-            iconCache.get(cacheKey)
-              ?: (if (allowDisk) loadIconFromDisk(cacheKey)?.also { iconCache.put(cacheKey, it) }
-              else null)
-              ?: run {
-                // Robust fallback: if IPC is allowed, try to load it now
-                if (allowIpc) {
-                  try {
-                    context.packageManager.getApplicationIcon(context.packageName).also {
-                      iconCache.put(cacheKey, it)
-                      if (saveToDisk) {
-                        saveIconToDisk(cacheKey, it, force = true)
-                      }
-                    }
-                  } catch (e: Exception) {
-                    null
-                  }
-                } else null
-              }
-          } else null
-
-        SearchResult.Content(
-          id = doc.id,
-          namespace = "app_shortcuts",
-          title = doc.name,
-          subtitle = if (isLauncherItem) "SearchLauncher" else "Action",
-          icon = launcherIcon ?: icon,
-          packageName = "android",
-          deepLink = doc.intentUri,
-          rankingScore = rankingScore,
-        )
-      }
-      "search_shortcuts" -> {
-        val alias = doc.description ?: ""
-        val cacheKey = "search_shortcut_${doc.id}"
-        var icon = iconCache.get(cacheKey)
-
-        if (icon == null) {
-          val app = context.applicationContext as? SearchLauncherApp
-          val shortcutDef = app?.searchShortcutRepository?.items?.value?.find { it.alias == alias }
-          icon = iconGenerator.getColoredSearchIcon(shortcutDef?.color, shortcutDef?.alias)
-          if (icon != null) {
-            iconCache.put(cacheKey, icon)
-          }
-        }
-
-        SearchResult.SearchIntent(
-          id = doc.id,
-          namespace = "search_shortcuts",
-          title = doc.name,
-          subtitle = "Type '${doc.description} ' to search",
-          icon = icon,
-          trigger = doc.description ?: "",
-          rankingScore = rankingScore,
-        )
-      }
-      "web_bookmarks" -> {
-        val browserIcon =
-          context.getDrawable(android.R.drawable.ic_menu_compass)
-            ?: context.getDrawable(android.R.drawable.ic_menu_search)
-        SearchResult.Content(
-          id = doc.id,
-          namespace = "web_bookmarks",
-          title = doc.name,
-          subtitle = "Bookmark",
-          icon = browserIcon,
-          packageName = "com.android.chrome",
-          deepLink = doc.intentUri,
-          rankingScore = rankingScore,
-        )
-      }
-      "static_shortcuts" -> {
-        var icon: Drawable? = iconCache.get("static_shortcut_${doc.id}")
-        if (icon == null && allowDisk) {
-          val diskIcon = loadIconFromDisk("static_shortcut_${doc.id}")
-          if (diskIcon != null) {
-            icon = diskIcon
-            iconCache.put("static_shortcut_${doc.id}", icon)
-          } else if (allowIpc) {
-            try {
-              val pkg = sdoc.packageName ?: ""
-              if (doc.iconResId > 0) {
-                val res = context.packageManager.getResourcesForApplication(pkg)
-                icon = res.getDrawable(doc.iconResId.toInt(), null)
-                if (icon != null) {
-                  iconCache.put("static_shortcut_${doc.id}", icon)
-                  if (saveToDisk) {
-                    saveIconToDisk("static_shortcut_${doc.id}", icon, force = true)
-                  }
-                }
-              }
-            } catch (e: Exception) {}
-          }
-        }
-
-        val pkg = sdoc.packageName ?: ""
-        val appIcon =
-          if (allowIpc) {
-            try {
-              context.packageManager.getApplicationIcon(pkg)
-            } catch (e: Exception) {
-              null
-            }
-          } else null
-
-        SearchResult.Shortcut(
-          id = doc.id,
-          namespace = "static_shortcuts",
-          title = doc.name,
-          subtitle = doc.description ?: "Shortcut",
-          icon = icon,
-          packageName = pkg,
-          intentUri = doc.intentUri ?: "",
-          appIcon = appIcon,
-          rankingScore = rankingScore,
-        )
-      }
-      "contacts" -> {
-        val lookupKey = sdoc.contactLookupKey ?: ""
-        val contactId = sdoc.contactId
-        val photoUri = sdoc.photoUri
-
-        var icon: Drawable? = iconCache.get("contact_${doc.id}")
-
-        if (icon == null && photoUri != null && allowIpc) {
-          try {
-            val uri = android.net.Uri.parse(photoUri)
-            val stream = context.contentResolver.openInputStream(uri)
-            icon = Drawable.createFromStream(stream, uri.toString())
-            stream?.close()
-            if (icon != null) {
-              iconCache.put("contact_${doc.id}", icon)
-            }
-          } catch (e: Exception) {
-            // Ignore
-          }
-        }
-
-        if (icon == null && allowIpc) {
-          icon = defaultContactIcon
-        }
-
-        SearchResult.Contact(
-          id = doc.id,
-          namespace = "contacts",
-          title = doc.name,
-          subtitle =
-            if (query != null && !doc.name.contains(query, ignoreCase = true)) {
-              val phoneNumbers = sdoc.phoneNumbers ?: ""
-              val tokens = phoneNumbers.split(" ")
-              val match = tokens.find { it.contains(query, ignoreCase = true) }
-              match?.trim() ?: "Contact"
-            } else {
-              "Contact"
-            },
-          icon = icon,
-          rankingScore = rankingScore,
-          lookupKey = lookupKey,
-          contactId = contactId,
-          photoUri = photoUri,
-        )
-      }
-      "snippets" -> {
-        val icon = context.getDrawable(android.R.drawable.ic_menu_save)
-        SearchResult.Snippet(
-          id = doc.id,
-          namespace = "snippets",
-          title = doc.name,
-          subtitle = doc.description ?: "Snippet",
-          icon = icon,
-          alias = doc.id,
-          content = doc.description ?: "",
-          rankingScore = rankingScore,
-        )
-      }
-      else -> { // apps
-        val packageName = doc.id
-        // App icons pre-cached during indexing/refresh
-        val icon =
-          iconCache.get("appicon_$packageName")
-            ?: (if (allowDisk)
-              loadIconFromDisk("appicon_$packageName")?.also {
-                iconCache.put("appicon_$packageName", it)
-              }
-            else null)
-            ?: (if (allowIpc) {
-              try {
-                context.packageManager.getApplicationIcon(packageName).also {
-                  iconCache.put("appicon_$packageName", it)
-                  if (saveToDisk) {
-                    saveIconToDisk("appicon_$packageName", it, force = true)
-                  }
-                }
-              } catch (e: Exception) {
-                android.util.Log.w(
-                  "SearchRepository",
-                  "Failed to load app icon on demand for $packageName",
-                )
-                null
-              }
-            } else null)
-        SearchResult.App(
-          id = doc.id,
-          namespace = "apps",
-          title = doc.name,
-          subtitle = doc.description ?: doc.id,
-          icon = icon,
-          packageName = doc.id,
-          rankingScore = rankingScore,
-        )
-      }
-    }
-  }
+  ): SearchResult =
+    searchResultFactory.create(sdoc, rankingScore, query, saveToDisk, allowIpc, allowDisk)
 
   private fun saveResultsToCache(results: List<SearchResult>, isFavorites: Boolean) {
     scope.launch(Dispatchers.IO) {
@@ -2713,7 +2026,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             }
           }
           array.put(obj)
-          saveIconToDisk(res.id, res.icon)
+          iconRepository.saveToDisk(res.id, res.icon)
         }
         file.writeText(array.toString())
       } catch (e: Exception) {
@@ -2721,19 +2034,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
     }
   }
-
-  private suspend fun cacheAppIcon(packageName: String, customKey: String? = null) =
-    withContext(Dispatchers.IO) {
-      try {
-        val key = customKey ?: "appicon_$packageName"
-        val icon = context.packageManager.getApplicationIcon(packageName)
-        iconCache.put(key, icon)
-        saveIconToDisk(key, icon, force = true)
-        android.util.Log.d("SearchRepository", "Cached icon for $packageName as $key")
-      } catch (e: Exception) {
-        android.util.Log.e("SearchRepository", "Failed to cache icon for $packageName", e)
-      }
-    }
 
   private fun loadResultsFromCache(isFavorites: Boolean): List<SearchResult> {
     val file = if (isFavorites) getFavoritesCacheFile() else getHistoryCacheFile()
@@ -2747,7 +2047,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         val ns = obj.getString("namespace")
         val title = obj.getString("title")
         val sub = obj.optString("subtitle", "").takeIf { it.isNotEmpty() }
-        val icon = loadIconFromDisk(id)
+        val icon = iconRepository.loadFromDisk(id)
         val res =
           when (obj.getString("type")) {
             "App" ->
@@ -2839,9 +2139,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private fun getGlobalUsageCount(namespace: String, id: String): Int =
     usageStats[usageKey(namespace, id)] ?: usageStats[id] ?: 0
 
-  private fun getQueryUsagePoints(query: String?, namespace: String, id: String): Int =
-    query?.let { queryUsageStats[queryUsageKey(it, namespace, id)] } ?: 0
-
   private fun recordQueryUsage(query: String, namespace: String, id: String) {
     val queryLength = query.length.coerceAtLeast(1)
     for (prefixLength in 1..queryLength) {
@@ -2917,48 +2214,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   private fun getHistoryCacheFile() = File(context.filesDir, "history_cache.json")
 
-  private fun getIconDir() = File(context.filesDir, "favorite_icons").apply { mkdirs() }
-
-  private fun sanitizeId(id: String) = id.replace("/", "_").replace(":", "_")
-
-  private fun hasIconOnDisk(id: String): Boolean =
-    File(getIconDir(), "${sanitizeId(id)}.png").exists()
-
-  private fun saveIconToDisk(id: String, drawable: Drawable?, force: Boolean = true) {
-    if (drawable == null || !force) return
-    val targetFile = File(getIconDir(), "${sanitizeId(id)}.png")
-    val tmpFile = File(getIconDir(), "${sanitizeId(id)}.tmp")
-
-    try {
-      val bitmap = Bitmap.createBitmap(ICON_SIZE_PX, ICON_SIZE_PX, Bitmap.Config.ARGB_8888)
-      val canvas = Canvas(bitmap)
-      drawable.setBounds(0, 0, canvas.width, canvas.height)
-      drawable.draw(canvas)
-
-      // Write to temp file first to avoid partial writes (race condition)
-      FileOutputStream(tmpFile).use { out ->
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
-        out.flush()
-      }
-      bitmap.recycle()
-
-      // Atomic replacement
-      if (tmpFile.exists() && tmpFile.length() > 0) {
-        if (targetFile.exists()) {
-          targetFile.delete()
-        }
-        tmpFile.renameTo(targetFile)
-      }
-    } catch (e: Exception) {
-      e.printStackTrace()
-      tmpFile.delete()
-    }
-  }
-
   suspend fun clearIconCache() {
-    iconCache.evictAll()
-    getIconDir().deleteRecursively()
-    getIconDir().mkdirs()
+    iconRepository.clearMemory()
+    iconRepository.clearDisk()
     // Re-index shortcuts to rebuild the disk cache.
     withContext(Dispatchers.IO) {
       try {
@@ -2981,13 +2239,13 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               val pkg = info.componentName.packageName
               try {
                 val appIcon = info.getIcon(context.resources.displayMetrics.densityDpi)
-                saveIconToDisk("appicon_$pkg", appIcon, force = true)
+                iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
                 iconCount++
               } catch (e: Exception) {
                 // Try PackageManager as fallback
                 try {
                   val appIcon = context.packageManager.getApplicationIcon(pkg)
-                  saveIconToDisk("appicon_$pkg", appIcon, force = true)
+                  iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
                   iconCount++
                 } catch (e2: Exception) {
                   // Ignore
@@ -3006,128 +2264,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     }
   }
 
-  private fun loadIconFromDisk(id: String): Drawable? {
-    val file = File(getIconDir(), "${sanitizeId(id)}.png")
-    if (!file.exists()) return null
-    return try {
-      val bitmap = BitmapFactory.decodeFile(file.absolutePath)
-      BitmapDrawable(context.resources, bitmap)
-    } catch (e: Exception) {
-      null
-    }
-  }
-
-  private fun chatPackageFromMimeType(mimeType: String): String? {
-    return KNOWN_CHAT_PACKAGES.firstOrNull { packageName ->
-      mimeType.contains(packageName, ignoreCase = true)
-    }
-  }
-
-  private fun getPrimaryPhoneNumber(contactId: Long): String? {
-    val cursor =
-      context.contentResolver.query(
-        android.provider.ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
-        arrayOf(android.provider.ContactsContract.CommonDataKinds.Phone.NUMBER),
-        "${android.provider.ContactsContract.CommonDataKinds.Phone.CONTACT_ID} = ?",
-        arrayOf(contactId.toString()),
-        "${android.provider.ContactsContract.CommonDataKinds.Phone.IS_PRIMARY} DESC",
-      )
-
-    cursor?.use {
-      val numberIndex =
-        it.getColumnIndex(android.provider.ContactsContract.CommonDataKinds.Phone.NUMBER)
-      while (it.moveToNext()) {
-        val number = it.getString(numberIndex)
-        if (!number.isNullOrBlank()) return number
-      }
-    }
-    return null
-  }
-
-  private fun getPrimaryEmailAddress(contactId: Long): String? {
-    val cursor =
-      context.contentResolver.query(
-        android.provider.ContactsContract.CommonDataKinds.Email.CONTENT_URI,
-        arrayOf(android.provider.ContactsContract.CommonDataKinds.Email.ADDRESS),
-        "${android.provider.ContactsContract.CommonDataKinds.Email.CONTACT_ID} = ?",
-        arrayOf(contactId.toString()),
-        "${android.provider.ContactsContract.CommonDataKinds.Email.IS_PRIMARY} DESC",
-      )
-
-    cursor?.use {
-      val addressIndex =
-        it.getColumnIndex(android.provider.ContactsContract.CommonDataKinds.Email.ADDRESS)
-      while (it.moveToNext()) {
-        val address = it.getString(addressIndex)
-        if (!address.isNullOrBlank()) return address
-      }
-    }
-    return null
-  }
-
-  private fun isPackageInstalled(packageName: String): Boolean =
-    try {
-      context.packageManager.getPackageInfo(packageName, 0)
-      true
-    } catch (e: Exception) {
-      false
-    }
-
-  private fun getApplicationLabel(packageName: String): String? =
-    try {
-      val appInfo = context.packageManager.getApplicationInfo(packageName, 0)
-      context.packageManager.getApplicationLabel(appInfo).toString()
-    } catch (e: Exception) {
-      null
-    }
-
-  private fun getApplicationIcon(packageName: String): Drawable? =
-    try {
-      iconCache.get("appicon_$packageName")
-        ?: context.packageManager.getApplicationIcon(packageName).also {
-          iconCache.put("appicon_$packageName", it)
-        }
-    } catch (e: Exception) {
-      null
-    }
-
-  private fun getLastContactChatPackage(contactId: String): String? =
-    context
-      .getSharedPreferences("contact_chat_actions", Context.MODE_PRIVATE)
-      .getString(contactId, null)
-
-  private fun setLastContactChatPackage(contactId: String, packageName: String) {
-    context
-      .getSharedPreferences("contact_chat_actions", Context.MODE_PRIVATE)
-      .edit()
-      .putString(contactId, packageName)
-      .apply()
-  }
-
   // checkSmartActions extracted to SmartActionManager
-
-  companion object {
-    private const val ICON_SIZE_PX = 192
-    private const val ICON_CACHE_MAX_KB = 24 * 1024
-    private const val CALL_ACTION_KEY = "com.searchlauncher.action.CALL_CONTACT"
-    private const val SMS_ACTION_KEY = "com.searchlauncher.action.SMS_CONTACT"
-    private const val EMAIL_ACTION_KEY = "com.searchlauncher.action.EMAIL_CONTACT"
-    private const val WHATSAPP_PACKAGE = "com.whatsapp"
-    private val KNOWN_CHAT_PACKAGES =
-      setOf(
-        WHATSAPP_PACKAGE,
-        "com.whatsapp.w4b",
-        "org.telegram.messenger",
-        "org.thunderdog.challegram",
-        "org.telegram.plus",
-        "com.facebook.orca",
-        "com.viber.voip",
-        "com.signal",
-        "org.thoughtcrime.securesms",
-        "com.google.android.apps.messaging",
-        "com.skype.raider",
-      )
-  }
 
   suspend fun loadIcon(result: SearchResult): Drawable? =
     withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -202,13 +202,13 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private var observedHistoryLimit: Int
     get() =
       context
-        .getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
-        .getInt("observed_history_limit", 10)
+        .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+        .getInt(Prefs.Launcher.OBSERVED_HISTORY_LIMIT, 10)
     set(value) {
       context
-        .getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
+        .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
         .edit()
-        .putInt("observed_history_limit", value)
+        .putInt(Prefs.Launcher.OBSERVED_HISTORY_LIMIT, value)
         .apply()
     }
 
@@ -339,8 +339,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         scope.launch {
           delay(2000) // Give the UI 2 seconds to load icons and settle
 
-          val prefs = context.getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
-          val lastReindex = prefs.getLong("last_reindex_timestamp", 0L)
+          val prefs = context.getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+          val lastReindex = prefs.getLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, 0L)
           val currentTime = System.currentTimeMillis()
           // Re-index only if empty or older than 4 hours
           val isStale = (currentTime - lastReindex) > (12 * 60 * 60 * 1000)
@@ -404,7 +404,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               "Background Re-indexing took ${System.currentTimeMillis() - backgroundStart}ms",
             )
             saveFastIndexCache()
-            prefs.edit().putLong("last_reindex_timestamp", System.currentTimeMillis()).apply()
+            prefs.edit().putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis()).apply()
             _indexUpdated.emit(Unit)
           } finally {
             _isIndexing.value = false
@@ -771,8 +771,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         }
 
         // Clear timestamp to ensure future "fresh" checks fail until we are done
-        val prefs = context.getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
-        prefs.edit().remove("last_reindex_timestamp").apply()
+        val prefs = context.getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+        prefs.edit().remove(Prefs.Launcher.LAST_REINDEX_TIMESTAMP).apply()
 
         // Re-index everything (indexApps etc. will re-populate documentCache)
         indexApps()
@@ -783,7 +783,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
         // warmupCache() - Removed
 
-        prefs.edit().putLong("last_reindex_timestamp", System.currentTimeMillis()).apply()
+        prefs.edit().putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis()).apply()
       } catch (e: Exception) {
         android.util.Log.e("SearchRepository", "Error during resetIndex", e)
         Sentry.captureException(e)

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -1258,6 +1258,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
           val sdocs =
             documentSnapshot
               .filter { it.namespaceInt == 1 } // apps
+              // Guard the app list's LazyColumn key against duplicate package ids that an older
+              // index/cache may still hold (a package can have several launcher activities).
+              .distinctBy { it.doc.id }
               .sortedBy { it.nameLower }
           val results =
             sdocs

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -404,7 +404,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               "Background Re-indexing took ${System.currentTimeMillis() - backgroundStart}ms",
             )
             saveFastIndexCache()
-            prefs.edit().putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis()).apply()
+            prefs
+              .edit()
+              .putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis())
+              .apply()
             _indexUpdated.emit(Unit)
           } finally {
             _isIndexing.value = false
@@ -783,7 +786,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
         // warmupCache() - Removed
 
-        prefs.edit().putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis()).apply()
+        prefs
+          .edit()
+          .putLong(Prefs.Launcher.LAST_REINDEX_TIMESTAMP, System.currentTimeMillis())
+          .apply()
       } catch (e: Exception) {
         android.util.Log.e("SearchRepository", "Error during resetIndex", e)
         Sentry.captureException(e)

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -1,7 +1,6 @@
 package com.searchlauncher.app.data
 
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.appsearch.app.AppSearchSession
@@ -15,7 +14,6 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.dataStore
-import com.searchlauncher.app.util.StaticShortcutScanner
 import com.searchlauncher.app.util.SystemUtils
 import com.searchlauncher.app.util.traceSection
 import io.sentry.Sentry
@@ -176,6 +174,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   private val iconGenerator = SearchIconGenerator(context)
   private val iconRepository = IconRepository(context)
   private val searchResultFactory = SearchResultFactory(context, iconRepository, iconGenerator)
+  private val appIndexer = AppIndexer(context)
+  private val shortcutIndexer = ShortcutIndexer(context, iconRepository)
+  private val contactIndexer = ContactIndexer(context)
+  private val snippetIndexer = SnippetIndexer(context)
 
   private val _isInitialized = kotlinx.coroutines.flow.MutableStateFlow(false)
   val isInitialized: kotlinx.coroutines.flow.StateFlow<Boolean> = _isInitialized
@@ -510,68 +512,13 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     withContext(Dispatchers.IO) {
       android.util.Log.d("SearchRepository", "Indexing apps...")
       val session = appSearchSession ?: return@withContext
-      val launcherApps =
-        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as android.content.pm.LauncherApps
-
-      val apps = mutableListOf<AppSearchDocument>()
 
       // Note: We NO LONGER clear the entire 'apps' namespace here.
       // Clearing the namespace also wipes usage stats (history).
       // Instead, we put new documents (updates existing ones) and later
       // we could implement a cleanup for apps that were uninstalled.
 
-      val profiles = launcherApps.profiles
-
-      for (profile in profiles) {
-        pauseIndexingIfSearchIsActive()
-        try {
-          // fetch activities directly per profile. This is more efficient and safer
-          // than getInstalledPackages which is prone to DeadObjectException.
-          val activityList = launcherApps.getActivityList(null, profile)
-
-          for (info in activityList) {
-            pauseIndexingIfSearchIsActive()
-            try {
-              val appName = info.label.toString()
-              val packageName = info.componentName.packageName
-
-              val appInfo = info.applicationInfo
-              val category =
-                when (appInfo.category) {
-                  ApplicationInfo.CATEGORY_GAME -> "Game"
-                  ApplicationInfo.CATEGORY_AUDIO -> "Audio"
-                  ApplicationInfo.CATEGORY_VIDEO -> "Video"
-                  ApplicationInfo.CATEGORY_IMAGE -> "Image"
-                  ApplicationInfo.CATEGORY_SOCIAL -> "Social"
-                  ApplicationInfo.CATEGORY_NEWS -> "News"
-                  ApplicationInfo.CATEGORY_MAPS -> "Maps"
-                  ApplicationInfo.CATEGORY_PRODUCTIVITY -> "Productivity"
-                  else -> "Application"
-                }
-
-              apps.add(
-                AppSearchDocument(
-                  namespace = "apps",
-                  id = packageName,
-                  name = appName,
-                  score = 2,
-                  description = category,
-                )
-              )
-            } catch (e: Exception) {
-              // Ignore individual app failures
-            }
-          }
-        } catch (e: android.os.DeadObjectException) {
-          android.util.Log.w(
-            "SearchRepository",
-            "System unavailable querying apps for profile $profile, skipping",
-          )
-        } catch (e: Exception) {
-          android.util.Log.e("SearchRepository", "Error querying apps for profile $profile", e)
-          Sentry.captureException(e)
-        }
-      }
+      val apps = appIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
 
       if (apps.isNotEmpty()) {
         // Batch AppSearch puts to avoid TransactionTooLargeException
@@ -640,9 +587,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   suspend fun indexShortcuts(packageNames: List<String>? = null) =
     withContext(Dispatchers.IO) {
       val session = appSearchSession ?: return@withContext
-      val launcherApps =
-        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as android.content.pm.LauncherApps
-      val profiles = launcherApps.profiles
 
       val isFullReindex = packageNames == null
       val packages =
@@ -680,96 +624,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         }
       }
 
-      val newShortcuts = mutableListOf<AppSearchDocument>()
-      val appNameCache = mutableMapOf<String, String>()
-
-      for (profile in profiles) {
-        pauseIndexingIfSearchIsActive()
-        for (packageName in packages) {
-          pauseIndexingIfSearchIsActive()
-          try {
-            val query = android.content.pm.LauncherApps.ShortcutQuery()
-            query.setQueryFlags(
-              android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
-            )
-            query.setPackage(packageName)
-
-            val shortcutList =
-              try {
-                launcherApps.getShortcuts(query, profile) ?: emptyList()
-              } catch (e: android.os.DeadObjectException) {
-                android.util.Log.w(
-                  "SearchRepository",
-                  "System unavailable querying shortcuts for $packageName, skipping",
-                )
-                return@withContext
-              } catch (e: Exception) {
-                emptyList()
-              }
-
-            for (shortcut in shortcutList) {
-              pauseIndexingIfSearchIsActive()
-              try {
-                val shortcutId = "${shortcut.`package`}/${shortcut.id}"
-                val name = shortcut.shortLabel?.toString() ?: shortcut.longLabel?.toString() ?: ""
-                val appName =
-                  appNameCache.getOrPut(shortcut.`package`) {
-                    try {
-                      val appInfo = context.packageManager.getApplicationInfo(shortcut.`package`, 0)
-                      context.packageManager.getApplicationLabel(appInfo).toString()
-                    } catch (e: Exception) {
-                      shortcut.`package`
-                    }
-                  }
-
-                try {
-                  val icon =
-                    launcherApps.getShortcutIconDrawable(
-                      shortcut,
-                      context.resources.displayMetrics.densityDpi,
-                    )
-                  if (icon != null) {
-                    iconRepository.saveToDisk("shortcut_$shortcutId", icon, force = true)
-                  }
-                } catch (e: Exception) {
-                  // Ignore icon loading failures
-                }
-
-                val pkg = shortcut.`package`
-                if (!iconRepository.hasOnDisk("appicon_$pkg")) {
-                  try {
-                    val appIcon = context.packageManager.getApplicationIcon(pkg)
-                    iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
-                  } catch (e: Exception) {
-                    // Ignore icon loading failures
-                  }
-                }
-
-                newShortcuts.add(
-                  AppSearchDocument(
-                    namespace = "shortcuts",
-                    id = shortcutId,
-                    name = name,
-                    score = 1,
-                    intentUri = "shortcut://${shortcut.`package`}/${shortcut.id}",
-                    description = "Shortcut - $appName",
-                  )
-                )
-              } catch (e: Exception) {
-                // Ignore individual shortcut failures
-              }
-            }
-          } catch (e: Exception) {
-            android.util.Log.w(
-              "SearchRepository",
-              "Failed to query shortcuts for package $packageName",
-              e,
-            )
-          }
-        }
-      }
+      val newShortcuts =
+        shortcutIndexer.buildDynamicDocuments(packages, ::pauseIndexingIfSearchIsActive)
+          ?: return@withContext
 
       if (newShortcuts.isNotEmpty()) {
         newShortcuts.chunked(50).forEach { chunk ->
@@ -802,8 +659,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
 
-      val app = context.applicationContext as? SearchLauncherApp ?: return@withContext
-
       // Remove old shortcuts first to prevent zombies
       try {
         val removeSpec =
@@ -814,36 +669,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         Sentry.captureException(e)
       }
 
-      // Index app-defined shortcuts (settings, actions)
-      val appShortcutDocs: List<AppSearchDocument> =
-        DefaultShortcuts.appShortcuts.map { shortcut ->
-          AppSearchDocument(
-            namespace = "app_shortcuts",
-            id = "app_${shortcut.id}",
-            name = shortcut.description,
-            score = 3,
-            description = (shortcut as? AppShortcut.Action)?.aliases,
-            intentUri = (shortcut as? AppShortcut.Action)?.intentUri,
-            isAction = true,
-          )
-        }
-
-      // Index user-editable search shortcuts
-      val searchShortcuts = app.searchShortcutRepository.items.value
-      val searchShortcutDocs: List<AppSearchDocument> =
-        searchShortcuts.map { shortcut ->
-          AppSearchDocument(
-            namespace = "search_shortcuts",
-            id = "search_${shortcut.id}",
-            name = shortcut.description,
-            score = 3,
-            description = shortcut.alias,
-            intentUri = shortcut.urlTemplate,
-            isAction = false,
-          )
-        }
-
-      val allDocs = appShortcutDocs + searchShortcutDocs
+      val allDocs = shortcutIndexer.buildCustomDocuments()
       if (allDocs.isNotEmpty()) {
         pauseIndexingIfSearchIsActive()
         val putRequest = PutDocumentsRequest.Builder().addDocuments(allDocs).build()
@@ -863,55 +689,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     withContext(Dispatchers.IO) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
-      val shortcuts = StaticShortcutScanner.scan(context)
-      val docs = mutableListOf<AppSearchDocument>()
-      for (s in shortcuts) {
-        pauseIndexingIfSearchIsActive()
-        val appName =
-          try {
-            val appInfo = context.packageManager.getApplicationInfo(s.packageName, 0)
-            context.packageManager.getApplicationLabel(appInfo).toString()
-          } catch (e: Exception) {
-            s.packageName
-          }
-
-        // Pre-load and cache static shortcut icon
-        val shortcutId = "${s.packageName}/${s.id}"
-        try {
-          if (s.iconResId > 0) {
-            val res = context.packageManager.getResourcesForApplication(s.packageName)
-            val icon = res.getDrawable(s.iconResId.toInt(), null)
-            if (icon != null) {
-              iconRepository.saveToDisk("static_shortcut_$shortcutId", icon, force = true)
-            }
-          }
-        } catch (e: Exception) {
-          // Ignore icon loading failures
-          Sentry.captureException(e)
-        }
-
-        // Pre-load and cache app icon
-        if (!iconRepository.hasOnDisk("appicon_${s.packageName}")) {
-          try {
-            val appIcon = context.packageManager.getApplicationIcon(s.packageName)
-            iconRepository.saveToDisk("appicon_${s.packageName}", appIcon, force = true)
-          } catch (e: Exception) {
-            // Ignore app icon loading failures
-            Sentry.captureException(e)
-          }
-        }
-
-        AppSearchDocument(
-            namespace = "static_shortcuts",
-            id = shortcutId,
-            name = "$appName: ${s.shortLabel}",
-            description = "Shortcut - $appName",
-            score = 1,
-            intentUri = s.intent.toUri(0),
-            iconResId = s.iconResId.toLong(),
-          )
-          .also { docs.add(it) }
-      }
+      val docs = shortcutIndexer.buildStaticDocuments(::pauseIndexingIfSearchIsActive)
 
       // Clear old entries
       pauseIndexingIfSearchIsActive()
@@ -942,101 +720,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
       android.util.Log.d("SearchRepository", "Indexing contacts...")
 
-      val contacts = mutableListOf<AppSearchDocument>()
-      // 1. Fetch search data (Phone numbers and Emails)
-      val searchDataMap = mutableMapOf<Long, StringBuilder>()
-      val dataCursor =
-        context.contentResolver.query(
-          android.provider.ContactsContract.Data.CONTENT_URI,
-          arrayOf(
-            android.provider.ContactsContract.Data.CONTACT_ID,
-            android.provider.ContactsContract.Data.MIMETYPE,
-            android.provider.ContactsContract.Data.DATA1,
-          ),
-          "${android.provider.ContactsContract.Data.MIMETYPE} IN (?, ?)",
-          arrayOf(
-            android.provider.ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE,
-            android.provider.ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE,
-          ),
-          null,
-        )
-
-      dataCursor?.use {
-        val contactIdIndex = it.getColumnIndex(android.provider.ContactsContract.Data.CONTACT_ID)
-        val mimeTypeIndex = it.getColumnIndex(android.provider.ContactsContract.Data.MIMETYPE)
-        val dataIndex = it.getColumnIndex(android.provider.ContactsContract.Data.DATA1)
-
-        while (it.moveToNext()) {
-          pauseIndexingIfSearchIsActive()
-          val contactId = it.getLong(contactIdIndex)
-          val mimeType = it.getString(mimeTypeIndex)
-          val data = it.getString(dataIndex)
-
-          if (data != null) {
-            val sb = searchDataMap.getOrPut(contactId) { StringBuilder() }
-            // Use space as separator for better tokenization
-            sb.append(" ").append(data)
-
-            // Normalize phone numbers and add variants (e.g. 06... for +31...)
-            if (
-              mimeType == android.provider.ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE
-            ) {
-              com.searchlauncher.app.util.ContactUtils.getIndexableVariants(data).forEach {
-                sb.append(" ").append(it)
-              }
-            }
-          }
-        }
-      }
-
-      // 2. Fetch Contacts and merge
-      val cursor =
-        context.contentResolver.query(
-          android.provider.ContactsContract.Contacts.CONTENT_URI,
-          arrayOf(
-            android.provider.ContactsContract.Contacts._ID,
-            android.provider.ContactsContract.Contacts.DISPLAY_NAME_PRIMARY,
-            android.provider.ContactsContract.Contacts.LOOKUP_KEY,
-            android.provider.ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
-          ),
-          null,
-          null,
-          null,
-        )
-
-      cursor?.use {
-        val idIndex = it.getColumnIndex(android.provider.ContactsContract.Contacts._ID)
-        val nameIndex =
-          it.getColumnIndex(android.provider.ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)
-        val lookupIndex = it.getColumnIndex(android.provider.ContactsContract.Contacts.LOOKUP_KEY)
-        val photoIndex =
-          it.getColumnIndex(android.provider.ContactsContract.Contacts.PHOTO_THUMBNAIL_URI)
-
-        while (it.moveToNext()) {
-          pauseIndexingIfSearchIsActive()
-          val id = it.getLong(idIndex)
-          val name = it.getString(nameIndex)
-          val lookupKey = it.getString(lookupIndex)
-          val photoUri = it.getString(photoIndex)
-
-          if (name != null) {
-            val extraData = searchDataMap[id]?.toString() ?: ""
-            // Store photoUri + delimiter + searchable text
-            val description = "${photoUri ?: ""}|$extraData"
-
-            contacts.add(
-              AppSearchDocument(
-                namespace = "contacts",
-                id = "$lookupKey/$id",
-                name = name,
-                description = description,
-                score = 4,
-                intentUri = "content://com.android.contacts/contacts/lookup/$lookupKey/$id",
-              )
-            )
-          }
-        }
-      }
+      val contacts = contactIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
 
       if (contacts.isNotEmpty()) {
         pauseIndexingIfSearchIsActive()
@@ -1547,26 +1231,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     withContext(Dispatchers.IO) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
-      val app = context.applicationContext as? SearchLauncherApp ?: return@withContext
 
       try {
-        val snippets = app.snippetsRepository.items.value
-        val docs =
-          snippets.map { snippet ->
-            AppSearchDocument(
-              namespace = "snippets",
-              id = snippet.alias,
-              name = snippet.alias,
-              description = snippet.content,
-              score = 5,
-              // Snippets don't really use intentUri for launching/Action,
-              // but we might need a dummy one or update schema if required.
-              // Assuming optional or strict checking is handled.
-              // Logic in SearchResultItem handles it via clipboard.
-              intentUri = "snippet://${snippet.alias}",
-              isAction = true,
-            )
-          }
+        val docs = snippetIndexer.buildDocuments()
 
         if (docs.isNotEmpty()) {
           val putRequest = PutDocumentsRequest.Builder().addDocuments(docs).build()

--- a/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
@@ -1,0 +1,409 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.content.pm.LauncherApps
+import android.graphics.Color
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Process
+import android.util.Log
+import com.searchlauncher.app.R
+import com.searchlauncher.app.SearchLauncherApp
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+class SearchResultFactory(
+  private val context: Context,
+  private val iconRepository: IconRepository,
+  private val iconGenerator: SearchIconGenerator,
+) {
+  private val defaultContactIcon: Drawable by lazy {
+    context.getDrawable(R.drawable.ic_contact_default)!!.apply { setTint(Color.GRAY) }
+  }
+
+  suspend fun create(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    query: String? = null,
+    saveToDisk: Boolean = false,
+    allowIpc: Boolean = true,
+    allowDisk: Boolean = true,
+  ): SearchResult {
+    val doc = sdoc.doc
+    currentCoroutineContext().ensureActive()
+    return when (doc.namespace) {
+      "shortcuts" -> createShortcutResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
+      "app_shortcuts" ->
+        createAppShortcutResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
+      "search_shortcuts" -> createSearchShortcutResult(sdoc, rankingScore)
+      "web_bookmarks" -> createWebBookmarkResult(sdoc, rankingScore)
+      "static_shortcuts" ->
+        createStaticShortcutResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
+      "contacts" -> createContactResult(sdoc, rankingScore, query, allowIpc)
+      "snippets" -> createSnippetResult(sdoc, rankingScore)
+      else -> createAppResult(sdoc, rankingScore, saveToDisk, allowIpc, allowDisk)
+    }
+  }
+
+  private fun createShortcutResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): SearchResult.Shortcut {
+    val doc = sdoc.doc
+    val pkg = sdoc.packageName ?: ""
+    val icon = loadShortcutIcon(sdoc, saveToDisk, allowIpc, allowDisk)
+    val appIcon = loadAppIcon(pkg, saveToDisk, allowIpc, allowDisk)
+
+    return SearchResult.Shortcut(
+      id = doc.id,
+      namespace = "shortcuts",
+      title = doc.name,
+      subtitle = doc.description ?: "Shortcut",
+      icon = icon,
+      packageName = pkg,
+      intentUri = doc.intentUri ?: "",
+      appIcon = appIcon,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createAppShortcutResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): SearchResult.Content {
+    val doc = sdoc.doc
+    val icon = loadAppShortcutIcon(doc, saveToDisk, allowIpc, allowDisk)
+    val isLauncherItem = doc.id.contains("launcher_")
+    val launcherIcon =
+      if (isLauncherItem) {
+        loadAppIcon(
+          context.packageName,
+          saveToDisk,
+          allowIpc,
+          allowDisk,
+          cacheKey = "launcher_app_icon",
+        )
+      } else {
+        null
+      }
+
+    return SearchResult.Content(
+      id = doc.id,
+      namespace = "app_shortcuts",
+      title = doc.name,
+      subtitle = if (isLauncherItem) "SearchLauncher" else "Action",
+      icon = launcherIcon ?: icon,
+      packageName = "android",
+      deepLink = doc.intentUri,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createSearchShortcutResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+  ): SearchResult.SearchIntent {
+    val doc = sdoc.doc
+    val alias = doc.description ?: ""
+    val cacheKey = "search_shortcut_${doc.id}"
+    var icon = iconRepository.getMemory(cacheKey)
+
+    if (icon == null) {
+      val app = context.applicationContext as? SearchLauncherApp
+      val shortcutDef = app?.searchShortcutRepository?.items?.value?.find { it.alias == alias }
+      icon = iconGenerator.getColoredSearchIcon(shortcutDef?.color, shortcutDef?.alias)
+      if (icon != null) {
+        iconRepository.putMemory(cacheKey, icon)
+      }
+    }
+
+    return SearchResult.SearchIntent(
+      id = doc.id,
+      namespace = "search_shortcuts",
+      title = doc.name,
+      subtitle = "Type '${doc.description} ' to search",
+      icon = icon,
+      trigger = doc.description ?: "",
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createWebBookmarkResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+  ): SearchResult.Content {
+    val doc = sdoc.doc
+    val browserIcon =
+      context.getDrawable(android.R.drawable.ic_menu_compass)
+        ?: context.getDrawable(android.R.drawable.ic_menu_search)
+
+    return SearchResult.Content(
+      id = doc.id,
+      namespace = "web_bookmarks",
+      title = doc.name,
+      subtitle = "Bookmark",
+      icon = browserIcon,
+      packageName = "com.android.chrome",
+      deepLink = doc.intentUri,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createStaticShortcutResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): SearchResult.Shortcut {
+    val doc = sdoc.doc
+    val pkg = sdoc.packageName ?: ""
+    val icon = loadStaticShortcutIcon(sdoc, saveToDisk, allowIpc, allowDisk)
+    val appIcon =
+      if (allowIpc) runCatching { context.packageManager.getApplicationIcon(pkg) }.getOrNull()
+      else null
+
+    return SearchResult.Shortcut(
+      id = doc.id,
+      namespace = "static_shortcuts",
+      title = doc.name,
+      subtitle = doc.description ?: "Shortcut",
+      icon = icon,
+      packageName = pkg,
+      intentUri = doc.intentUri ?: "",
+      appIcon = appIcon,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createContactResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    query: String?,
+    allowIpc: Boolean,
+  ): SearchResult.Contact {
+    val doc = sdoc.doc
+    val lookupKey = sdoc.contactLookupKey ?: ""
+    val contactId = sdoc.contactId
+    val photoUri = sdoc.photoUri
+    val icon = loadContactIcon(doc.id, photoUri, allowIpc)
+
+    return SearchResult.Contact(
+      id = doc.id,
+      namespace = "contacts",
+      title = doc.name,
+      subtitle = contactSubtitle(sdoc, query),
+      icon = icon,
+      rankingScore = rankingScore,
+      lookupKey = lookupKey,
+      contactId = contactId,
+      photoUri = photoUri,
+    )
+  }
+
+  private fun createSnippetResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+  ): SearchResult.Snippet {
+    val doc = sdoc.doc
+    val icon = context.getDrawable(android.R.drawable.ic_menu_save)
+    return SearchResult.Snippet(
+      id = doc.id,
+      namespace = "snippets",
+      title = doc.name,
+      subtitle = doc.description ?: "Snippet",
+      icon = icon,
+      alias = doc.id,
+      content = doc.description ?: "",
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun createAppResult(
+    sdoc: SearchableDocument,
+    rankingScore: Int,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): SearchResult.App {
+    val doc = sdoc.doc
+    val packageName = doc.id
+    val icon = loadAppIcon(packageName, saveToDisk, allowIpc, allowDisk)
+
+    return SearchResult.App(
+      id = doc.id,
+      namespace = "apps",
+      title = doc.name,
+      subtitle = doc.description ?: doc.id,
+      icon = icon,
+      packageName = doc.id,
+      rankingScore = rankingScore,
+    )
+  }
+
+  private fun loadShortcutIcon(
+    sdoc: SearchableDocument,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): Drawable? {
+    val doc = sdoc.doc
+    val cacheKey = "shortcut_${doc.id}"
+    return loadCachedIcon(cacheKey, allowDisk)
+      ?: if (allowIpc) loadShortcutIconViaLauncherApps(sdoc, cacheKey, saveToDisk) else null
+  }
+
+  private fun loadShortcutIconViaLauncherApps(
+    sdoc: SearchableDocument,
+    cacheKey: String,
+    saveToDisk: Boolean,
+  ): Drawable? =
+    try {
+      val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+      val query = LauncherApps.ShortcutQuery()
+      query.setPackage(sdoc.packageName ?: "")
+      query.setShortcutIds(listOf(sdoc.doc.id.substringAfter("/")))
+      query.setQueryFlags(
+        LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+          LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+          LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
+      )
+      val shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle())
+      val icon =
+        shortcuts
+          ?.takeIf { it.isNotEmpty() }
+          ?.let {
+            launcherApps.getShortcutIconDrawable(it[0], context.resources.displayMetrics.densityDpi)
+          }
+      icon?.also { cacheIcon(cacheKey, it, saveToDisk) }
+    } catch (e: Exception) {
+      null
+    }
+
+  private fun loadAppShortcutIcon(
+    doc: AppSearchDocument,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): Drawable? {
+    val cacheKey = "app_shortcut_${doc.id}"
+    return loadCachedIcon(cacheKey, allowDisk)
+      ?: if (allowIpc) {
+        val icon =
+          when {
+            doc.intentUri?.contains("android.settings") == true ->
+              runCatching { context.packageManager.getApplicationIcon("com.android.settings") }
+                .getOrNull()
+            doc.intentUri?.contains("STILL_IMAGE_CAMERA") == true ->
+              context.getDrawable(android.R.drawable.ic_menu_camera)
+            doc.intentUri?.contains("VIDEO_CAMERA") == true ->
+              context.getDrawable(android.R.drawable.ic_menu_camera)
+            else -> null
+          }
+        icon?.also { cacheIcon(cacheKey, it, saveToDisk) }
+      } else {
+        null
+      }
+  }
+
+  private fun loadStaticShortcutIcon(
+    sdoc: SearchableDocument,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+  ): Drawable? {
+    val doc = sdoc.doc
+    val cacheKey = "static_shortcut_${doc.id}"
+    return loadCachedIcon(cacheKey, allowDisk)
+      ?: if (allowIpc) {
+        try {
+          val pkg = sdoc.packageName ?: ""
+          if (doc.iconResId > 0) {
+            context.packageManager
+              .getResourcesForApplication(pkg)
+              .getDrawable(doc.iconResId.toInt(), null)
+              .also { cacheIcon(cacheKey, it, saveToDisk) }
+          } else {
+            null
+          }
+        } catch (e: Exception) {
+          null
+        }
+      } else {
+        null
+      }
+  }
+
+  private fun loadContactIcon(id: String, photoUri: String?, allowIpc: Boolean): Drawable? {
+    val cacheKey = "contact_$id"
+    var icon = iconRepository.getMemory(cacheKey)
+
+    if (icon == null && photoUri != null && allowIpc) {
+      try {
+        val uri = Uri.parse(photoUri)
+        val stream = context.contentResolver.openInputStream(uri)
+        icon = Drawable.createFromStream(stream, uri.toString())
+        stream?.close()
+        if (icon != null) {
+          iconRepository.putMemory(cacheKey, icon)
+        }
+      } catch (e: Exception) {
+        // Ignore invalid or inaccessible contact photos.
+      }
+    }
+
+    return icon ?: if (allowIpc) defaultContactIcon else null
+  }
+
+  private fun loadAppIcon(
+    packageName: String,
+    saveToDisk: Boolean,
+    allowIpc: Boolean,
+    allowDisk: Boolean,
+    cacheKey: String = "appicon_$packageName",
+  ): Drawable? =
+    loadCachedIcon(cacheKey, allowDisk)
+      ?: if (allowIpc) {
+        try {
+          context.packageManager.getApplicationIcon(packageName).also {
+            cacheIcon(cacheKey, it, saveToDisk)
+          }
+        } catch (e: Exception) {
+          Log.w("SearchResultFactory", "Failed to load app icon on demand for $packageName")
+          null
+        }
+      } else {
+        null
+      }
+
+  private fun loadCachedIcon(cacheKey: String, allowDisk: Boolean): Drawable? {
+    iconRepository.getMemory(cacheKey)?.let {
+      return it
+    }
+    if (!allowDisk) return null
+    return iconRepository.loadFromDisk(cacheKey)?.also { iconRepository.putMemory(cacheKey, it) }
+  }
+
+  private fun cacheIcon(cacheKey: String, icon: Drawable, saveToDisk: Boolean) {
+    iconRepository.putMemory(cacheKey, icon)
+    if (saveToDisk) {
+      iconRepository.saveToDisk(cacheKey, icon, force = true)
+    }
+  }
+
+  private fun contactSubtitle(sdoc: SearchableDocument, query: String?): String {
+    val doc = sdoc.doc
+    if (query == null || doc.name.contains(query, ignoreCase = true)) {
+      return "Contact"
+    }
+
+    val tokens = (sdoc.phoneNumbers ?: "").split(" ")
+    return tokens.find { it.contains(query, ignoreCase = true) }?.trim() ?: "Contact"
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SearchShortcutRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchShortcutRepository.kt
@@ -15,7 +15,7 @@ import org.json.JSONObject
  */
 class SearchShortcutRepository(context: Context) {
   private val prefs: SharedPreferences =
-    context.getSharedPreferences("search_shortcuts", Context.MODE_PRIVATE)
+    context.getSharedPreferences(Prefs.SearchShortcuts.FILE, Context.MODE_PRIVATE)
 
   private val _items = MutableStateFlow<List<SearchShortcut>>(emptyList())
   val items: StateFlow<List<SearchShortcut>> = _items
@@ -25,7 +25,7 @@ class SearchShortcutRepository(context: Context) {
   }
 
   private fun loadItems() {
-    val json = prefs.getString("shortcuts", null)
+    val json = prefs.getString(Prefs.SearchShortcuts.SHORTCUTS, null)
     if (json == null) {
       // First run, load defaults
       resetToDefaults()
@@ -128,7 +128,7 @@ class SearchShortcutRepository(context: Context) {
       item.shortLabel?.let { obj.put("shortLabel", it) }
       jsonArray.put(obj)
     }
-    prefs.edit().putString("shortcuts", jsonArray.toString()).apply()
+    prefs.edit().putString(Prefs.SearchShortcuts.SHORTCUTS, jsonArray.toString()).apply()
     _items.value = items
   }
 

--- a/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
@@ -15,24 +15,20 @@ import io.sentry.Sentry
  * These are pure readers (aside from caching icons to disk as a side effect). Persisting the
  * documents is the caller's responsibility.
  */
-class ShortcutIndexer(
-  private val context: Context,
-  private val iconRepository: IconRepository,
-) {
+class ShortcutIndexer(private val context: Context, private val iconRepository: IconRepository) {
 
   /**
-   * Reads dynamic/manifest/pinned shortcuts for the given [packages] across all profiles and
-   * caches their icons to disk.
+   * Reads dynamic/manifest/pinned shortcuts for the given [packages] across all profiles and caches
+   * their icons to disk.
    *
-   * Returns null if the system shortcut service became unavailable mid-scan (the caller should
-   * then abandon the index update), otherwise the collected documents.
+   * Returns null if the system shortcut service became unavailable mid-scan (the caller should then
+   * abandon the index update), otherwise the collected documents.
    */
   suspend fun buildDynamicDocuments(
     packages: List<String>,
     pauseCheck: suspend () -> Unit,
   ): List<AppSearchDocument>? {
-    val launcherApps =
-      context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+    val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
 
     val newShortcuts = mutableListOf<AppSearchDocument>()
     val appNameCache = mutableMapOf<String, String>()

--- a/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
@@ -1,0 +1,226 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.content.pm.LauncherApps
+import com.searchlauncher.app.SearchLauncherApp
+import com.searchlauncher.app.util.StaticShortcutScanner
+import io.sentry.Sentry
+
+/**
+ * Builds AppSearch documents for the three flavours of shortcut the launcher indexes:
+ * - dynamic/pinned/manifest shortcuts published by other apps via [LauncherApps]
+ * - static shortcuts declared in app manifests (scanned by [StaticShortcutScanner])
+ * - the launcher's own app actions and user-defined search shortcuts
+ *
+ * These are pure readers (aside from caching icons to disk as a side effect). Persisting the
+ * documents is the caller's responsibility.
+ */
+class ShortcutIndexer(
+  private val context: Context,
+  private val iconRepository: IconRepository,
+) {
+
+  /**
+   * Reads dynamic/manifest/pinned shortcuts for the given [packages] across all profiles and
+   * caches their icons to disk.
+   *
+   * Returns null if the system shortcut service became unavailable mid-scan (the caller should
+   * then abandon the index update), otherwise the collected documents.
+   */
+  suspend fun buildDynamicDocuments(
+    packages: List<String>,
+    pauseCheck: suspend () -> Unit,
+  ): List<AppSearchDocument>? {
+    val launcherApps =
+      context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+
+    val newShortcuts = mutableListOf<AppSearchDocument>()
+    val appNameCache = mutableMapOf<String, String>()
+
+    for (profile in launcherApps.profiles) {
+      pauseCheck()
+      for (packageName in packages) {
+        pauseCheck()
+        try {
+          val query = LauncherApps.ShortcutQuery()
+          query.setQueryFlags(
+            LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+              LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+              LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
+          )
+          query.setPackage(packageName)
+
+          val shortcutList =
+            try {
+              launcherApps.getShortcuts(query, profile) ?: emptyList()
+            } catch (e: android.os.DeadObjectException) {
+              android.util.Log.w(
+                "SearchRepository",
+                "System unavailable querying shortcuts for $packageName, skipping",
+              )
+              return null
+            } catch (e: Exception) {
+              emptyList()
+            }
+
+          for (shortcut in shortcutList) {
+            pauseCheck()
+            try {
+              val shortcutId = "${shortcut.`package`}/${shortcut.id}"
+              val name = shortcut.shortLabel?.toString() ?: shortcut.longLabel?.toString() ?: ""
+              val appName =
+                appNameCache.getOrPut(shortcut.`package`) {
+                  try {
+                    val appInfo = context.packageManager.getApplicationInfo(shortcut.`package`, 0)
+                    context.packageManager.getApplicationLabel(appInfo).toString()
+                  } catch (e: Exception) {
+                    shortcut.`package`
+                  }
+                }
+
+              try {
+                val icon =
+                  launcherApps.getShortcutIconDrawable(
+                    shortcut,
+                    context.resources.displayMetrics.densityDpi,
+                  )
+                if (icon != null) {
+                  iconRepository.saveToDisk("shortcut_$shortcutId", icon, force = true)
+                }
+              } catch (e: Exception) {
+                // Ignore icon loading failures
+              }
+
+              val pkg = shortcut.`package`
+              if (!iconRepository.hasOnDisk("appicon_$pkg")) {
+                try {
+                  val appIcon = context.packageManager.getApplicationIcon(pkg)
+                  iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
+                } catch (e: Exception) {
+                  // Ignore icon loading failures
+                }
+              }
+
+              newShortcuts.add(
+                AppSearchDocument(
+                  namespace = "shortcuts",
+                  id = shortcutId,
+                  name = name,
+                  score = 1,
+                  intentUri = "shortcut://${shortcut.`package`}/${shortcut.id}",
+                  description = "Shortcut - $appName",
+                )
+              )
+            } catch (e: Exception) {
+              // Ignore individual shortcut failures
+            }
+          }
+        } catch (e: Exception) {
+          android.util.Log.w(
+            "SearchRepository",
+            "Failed to query shortcuts for package $packageName",
+            e,
+          )
+        }
+      }
+    }
+
+    return newShortcuts
+  }
+
+  /** Scans static (manifest-declared) shortcuts, caching their icons and app icons to disk. */
+  suspend fun buildStaticDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+    val shortcuts = StaticShortcutScanner.scan(context)
+    val docs = mutableListOf<AppSearchDocument>()
+    for (s in shortcuts) {
+      pauseCheck()
+      val appName =
+        try {
+          val appInfo = context.packageManager.getApplicationInfo(s.packageName, 0)
+          context.packageManager.getApplicationLabel(appInfo).toString()
+        } catch (e: Exception) {
+          s.packageName
+        }
+
+      // Pre-load and cache static shortcut icon
+      val shortcutId = "${s.packageName}/${s.id}"
+      try {
+        if (s.iconResId > 0) {
+          val res = context.packageManager.getResourcesForApplication(s.packageName)
+          val icon = res.getDrawable(s.iconResId.toInt(), null)
+          if (icon != null) {
+            iconRepository.saveToDisk("static_shortcut_$shortcutId", icon, force = true)
+          }
+        }
+      } catch (e: Exception) {
+        // Ignore icon loading failures
+        Sentry.captureException(e)
+      }
+
+      // Pre-load and cache app icon
+      if (!iconRepository.hasOnDisk("appicon_${s.packageName}")) {
+        try {
+          val appIcon = context.packageManager.getApplicationIcon(s.packageName)
+          iconRepository.saveToDisk("appicon_${s.packageName}", appIcon, force = true)
+        } catch (e: Exception) {
+          // Ignore app icon loading failures
+          Sentry.captureException(e)
+        }
+      }
+
+      docs.add(
+        AppSearchDocument(
+          namespace = "static_shortcuts",
+          id = shortcutId,
+          name = "$appName: ${s.shortLabel}",
+          description = "Shortcut - $appName",
+          score = 1,
+          intentUri = s.intent.toUri(0),
+          iconResId = s.iconResId.toLong(),
+        )
+      )
+    }
+    return docs
+  }
+
+  /**
+   * Builds the launcher's own action shortcuts (settings, actions) and the user's editable search
+   * shortcuts. Returns an empty list if the app context is unavailable.
+   *
+   * App-defined shortcuts use the `app_shortcuts` namespace; search shortcuts use
+   * `search_shortcuts`.
+   */
+  fun buildCustomDocuments(): List<AppSearchDocument> {
+    val app = context.applicationContext as? SearchLauncherApp ?: return emptyList()
+
+    // Index app-defined shortcuts (settings, actions)
+    val appShortcutDocs =
+      DefaultShortcuts.appShortcuts.map { shortcut ->
+        AppSearchDocument(
+          namespace = "app_shortcuts",
+          id = "app_${shortcut.id}",
+          name = shortcut.description,
+          score = 3,
+          description = (shortcut as? AppShortcut.Action)?.aliases,
+          intentUri = (shortcut as? AppShortcut.Action)?.intentUri,
+          isAction = true,
+        )
+      }
+
+    // Index user-editable search shortcuts
+    val searchShortcutDocs =
+      app.searchShortcutRepository.items.value.map { shortcut ->
+        AppSearchDocument(
+          namespace = "search_shortcuts",
+          id = "search_${shortcut.id}",
+          name = shortcut.description,
+          score = 3,
+          description = shortcut.alias,
+          intentUri = shortcut.urlTemplate,
+          isAction = false,
+        )
+      }
+
+    return appShortcutDocs + searchShortcutDocs
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SnippetIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SnippetIndexer.kt
@@ -1,0 +1,29 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import com.searchlauncher.app.SearchLauncherApp
+
+/**
+ * Builds AppSearch documents for user-defined text snippets.
+ *
+ * Snippets are launched via the clipboard (see SearchResultItem), so [AppSearchDocument.intentUri]
+ * carries a `snippet://` marker rather than a real launch intent.
+ */
+class SnippetIndexer(private val context: Context) {
+
+  /** Returns one document per snippet, or an empty list if the app context is unavailable. */
+  fun buildDocuments(): List<AppSearchDocument> {
+    val app = context.applicationContext as? SearchLauncherApp ?: return emptyList()
+    return app.snippetsRepository.items.value.map { snippet ->
+      AppSearchDocument(
+        namespace = "snippets",
+        id = snippet.alias,
+        name = snippet.alias,
+        description = snippet.content,
+        score = 5,
+        intentUri = "snippet://${snippet.alias}",
+        isAction = true,
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SnippetsRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SnippetsRepository.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
 
 class SnippetsRepository(context: Context) {
   private val prefs: SharedPreferences =
-    context.getSharedPreferences("quick_copy", Context.MODE_PRIVATE)
+    context.getSharedPreferences(Prefs.Snippets.FILE, Context.MODE_PRIVATE)
 
   private val _items = MutableStateFlow<List<SnippetItem>>(emptyList())
   val items: StateFlow<List<SnippetItem>> = _items
@@ -20,7 +20,7 @@ class SnippetsRepository(context: Context) {
   }
 
   private fun loadItems() {
-    val json = prefs.getString("items", "[]") ?: "[]"
+    val json = prefs.getString(Prefs.Snippets.ITEMS, "[]") ?: "[]"
     try {
       val jsonArray = JSONArray(json)
       val items = mutableListOf<SnippetItem>()
@@ -74,7 +74,7 @@ class SnippetsRepository(context: Context) {
       obj.put("content", item.content)
       jsonArray.put(obj)
     }
-    prefs.edit().putString("items", jsonArray.toString()).apply()
+    prefs.edit().putString(Prefs.Snippets.ITEMS, jsonArray.toString()).apply()
   }
 
   fun searchItems(query: String): List<SnippetItem> {

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -853,7 +853,20 @@ class MainActivity : ComponentActivity() {
         AppListScreen(
           searchRepository = app.searchRepository,
           onAppClick = { result ->
-            launchApp(context, result)
+            ResultLauncher(
+                context = context,
+                searchRepository = app.searchRepository,
+                scope = lifecycleScope,
+                onBindWidgetIntent = { intent ->
+                  handleWidgetIntent(intent)
+                  true
+                },
+                onAddWidgetSearch = {
+                  updateQueryState("widgets ")
+                  focusTrigger = System.currentTimeMillis()
+                },
+              )
+              .launch(result, reportUsage = false)
             currentScreenState = Screen.Search
             clearQueryState()
           },
@@ -871,47 +884,6 @@ class MainActivity : ComponentActivity() {
         onWidgetSelected = { info -> onWidgetProviderSelected(info) },
         onDismiss = { showWidgetPicker.value = false },
       )
-    }
-  }
-
-  private fun launchApp(context: Context, result: com.searchlauncher.app.data.SearchResult) {
-    try {
-      if (result is com.searchlauncher.app.data.SearchResult.Shortcut) {
-        val intent = Intent.parseUri(result.intentUri, Intent.URI_INTENT_SCHEME)
-
-        // Intercept Widget Binding
-        if (intent.action == "com.searchlauncher.action.BIND_WIDGET") {
-          val componentNameStr = intent.getStringExtra("component")
-          if (componentNameStr != null) {
-            val component = android.content.ComponentName.unflattenFromString(componentNameStr)
-            if (component != null) {
-              val providers =
-                appWidgetManager.getInstalledProvidersForProfile(android.os.Process.myUserHandle())
-              val providerInfo = providers.find { it.provider == component }
-              if (providerInfo != null) {
-                onWidgetProviderSelected(providerInfo)
-                return
-              }
-            }
-          }
-        }
-
-        // Intercept Widget Add Intent
-        if (intent.action == "com.searchlauncher.action.ADD_WIDGET") {
-          updateQueryState("widgets ")
-          focusTrigger = System.currentTimeMillis()
-          return
-        }
-
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-      } else if (result is com.searchlauncher.app.data.SearchResult.App) {
-        val intent = context.packageManager.getLaunchIntentForPackage(result.packageName)
-        intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-      }
-    } catch (e: Exception) {
-      Toast.makeText(context, "Cannot launch app", Toast.LENGTH_SHORT).show()
     }
   }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.searchlauncher.app.SearchLauncherApp
+import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.ui.theme.SearchLauncherTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -318,7 +319,7 @@ class MainActivity : ComponentActivity() {
   private var pendingSettingsSection by mutableStateOf<String?>(null)
   private var focusTrigger by mutableStateOf(0L)
 
-  private fun queryPrefs() = getSharedPreferences("active_search", Context.MODE_PRIVATE)
+  private fun queryPrefs() = getSharedPreferences(Prefs.ActiveSearch.FILE, Context.MODE_PRIVATE)
 
   private fun updateQueryState(value: String) {
     queryState = value
@@ -900,8 +901,8 @@ class MainActivity : ComponentActivity() {
   }
 
   companion object {
-    private const val KEY_ACTIVE_QUERY = "active_query"
-    private const val KEY_ACTIVE_QUERY_TIME = "active_query_time"
+    private const val KEY_ACTIVE_QUERY = Prefs.ActiveSearch.QUERY
+    private const val KEY_ACTIVE_QUERY_TIME = Prefs.ActiveSearch.QUERY_TIME
     private const val ACTIVE_QUERY_RESTORE_WINDOW_MS = 5 * 60 * 1000L
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/MinIconSize.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MinIconSize.kt
@@ -1,0 +1,38 @@
+package com.searchlauncher.app.ui
+
+import android.content.Context
+import com.searchlauncher.app.data.Prefs
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * The minimum search-result icon size, in dp.
+ *
+ * DataStore ([PreferencesKeys.MIN_ICON_SIZE]) is the source of truth, but the value is mirrored to a
+ * synchronous SharedPreferences cache ([Prefs.Launcher.MIN_ICON_SIZE]) so the first frame after a
+ * cold start can size icons immediately, rather than rendering at the default and snapping once the
+ * async DataStore read completes.
+ */
+object MinIconSize {
+
+  /** Source-of-truth flow from DataStore, falling back to the device default. */
+  fun flow(context: Context): Flow<Int> =
+    context.dataStore.data.map {
+      it[PreferencesKeys.MIN_ICON_SIZE] ?: PreferencesKeys.getDefaultIconSize(context)
+    }
+
+  /** Synchronously readable boot cache, used to seed the initial UI state before [flow] emits. */
+  fun cached(context: Context): Int =
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .getInt(Prefs.Launcher.MIN_ICON_SIZE, PreferencesKeys.getDefaultIconSize(context))
+
+  /** Refreshes the boot cache so the next cold start can render at [size] without waiting. */
+  fun updateCache(context: Context, size: Int) {
+    context
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+      .edit()
+      .putInt(Prefs.Launcher.MIN_ICON_SIZE, size)
+      .apply()
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/MinIconSize.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/MinIconSize.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.flow.map
 /**
  * The minimum search-result icon size, in dp.
  *
- * DataStore ([PreferencesKeys.MIN_ICON_SIZE]) is the source of truth, but the value is mirrored to a
- * synchronous SharedPreferences cache ([Prefs.Launcher.MIN_ICON_SIZE]) so the first frame after a
+ * DataStore ([PreferencesKeys.MIN_ICON_SIZE]) is the source of truth, but the value is mirrored to
+ * a synchronous SharedPreferences cache ([Prefs.Launcher.MIN_ICON_SIZE]) so the first frame after a
  * cold start can size icons immediately, rather than rendering at the default and snapping once the
  * async DataStore read completes.
  */

--- a/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/ResultLauncher.kt
@@ -1,0 +1,206 @@
+package com.searchlauncher.app.ui
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import com.searchlauncher.app.data.SearchRepository
+import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.ui.onboarding.OnboardingManager
+import com.searchlauncher.app.util.CustomActionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ResultLauncher(
+  private val context: Context,
+  private val searchRepository: SearchRepository,
+  private val scope: CoroutineScope,
+  private val onQueryChange: ((String) -> Unit)? = null,
+  private val onBindWidgetIntent: ((Intent) -> Boolean)? = null,
+  private val onAddWidgetSearch: (() -> Unit)? = null,
+  private val onboardingManager: OnboardingManager? = null,
+) {
+  fun launch(
+    result: SearchResult,
+    query: String = "",
+    wasFirstResult: Boolean = false,
+    reportUsage: Boolean = true,
+  ) {
+    when (result) {
+      is SearchResult.App -> launchApp(result)
+      is SearchResult.Content -> launchContent(result, query)
+      is SearchResult.Shortcut -> launchShortcut(result, query)
+      is SearchResult.SearchIntent -> {
+        // Search intents are handled by SearchScreen because they affect query mode.
+      }
+      is SearchResult.Contact -> launchContact(result)
+      is SearchResult.Snippet -> copySnippet(result)
+    }
+
+    if (reportUsage) {
+      searchRepository.reportUsageAsync(result.namespace, result.id, query, wasFirstResult)
+    }
+  }
+
+  private fun launchApp(result: SearchResult.App) {
+    val launchIntent = context.packageManager.getLaunchIntentForPackage(result.packageName)
+    launchIntent?.let {
+      it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      context.startActivity(it)
+    }
+  }
+
+  private fun launchContent(result: SearchResult.Content, query: String) {
+    val deepLink = result.deepLink ?: return
+
+    if (deepLink.startsWith("calculator://copy")) {
+      val textToCopy = Uri.parse(deepLink).getQueryParameter("text") ?: result.title
+      val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+      val clip = ClipData.newPlainText("Calculator Result", textToCopy)
+      clipboard.setPrimaryClip(clip)
+      Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    if (deepLink.startsWith("timer://set")) {
+      val uri = Uri.parse(deepLink)
+      val seconds = uri.getQueryParameter("seconds")?.toIntOrNull() ?: return
+      val name = uri.getQueryParameter("name")
+      val timerIntent =
+        Intent(android.provider.AlarmClock.ACTION_SET_TIMER).apply {
+          putExtra(android.provider.AlarmClock.EXTRA_LENGTH, seconds)
+          if (name != null) putExtra(android.provider.AlarmClock.EXTRA_MESSAGE, name)
+          addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+      try {
+        context.startActivity(timerIntent)
+      } catch (e: android.content.ActivityNotFoundException) {
+        Toast.makeText(context, "No timer app found", Toast.LENGTH_SHORT).show()
+      }
+      return
+    }
+
+    try {
+      val intent =
+        if (deepLink.startsWith("intent:")) {
+          Intent.parseUri(deepLink, Intent.URI_INTENT_SCHEME)
+        } else {
+          Intent(Intent.ACTION_VIEW, Uri.parse(deepLink))
+        }
+      launchIntent(intent, query)
+    } catch (e: Exception) {
+      e.printStackTrace()
+      Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  private fun launchShortcut(result: SearchResult.Shortcut, query: String) {
+    try {
+      val uri = result.intentUri
+      if (uri.startsWith("shortcut://")) {
+        val parts = uri.substring("shortcut://".length).split("/")
+        if (parts.size == 2) {
+          val pkg = parts[0]
+          val id = parts[1]
+          val launcherApps =
+            context.getSystemService(Context.LAUNCHER_APPS_SERVICE)
+              as android.content.pm.LauncherApps
+          launcherApps.startShortcut(pkg, id, null, null, android.os.Process.myUserHandle())
+        }
+      } else {
+        launchIntent(Intent.parseUri(uri, Intent.URI_INTENT_SCHEME), query)
+      }
+    } catch (e: Exception) {
+      e.printStackTrace()
+      Toast.makeText(context, "Error launching shortcut", Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  private fun launchIntent(intent: Intent, query: String) {
+    when (intent.action) {
+      ACTION_BIND_WIDGET -> {
+        val handled = onBindWidgetIntent?.invoke(intent) == true
+        if (!handled) {
+          Toast.makeText(context, "Cannot bind widget: Activity not found", Toast.LENGTH_SHORT)
+            .show()
+        }
+      }
+      ACTION_APPEND_SPACE -> onQueryChange?.invoke(query + " ")
+      ACTION_ADD_WIDGET -> onAddWidgetSearch?.invoke()
+      ACTION_RESET_INDEX -> resetIndex()
+      ACTION_RESET_APP_DATA -> resetAppData()
+      ACTION_RESET_ONBOARDING -> resetOnboarding()
+      else -> {
+        if (!CustomActionHandler.handleAction(context, intent)) {
+          intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          context.startActivity(intent)
+        }
+      }
+    }
+  }
+
+  private fun resetIndex() {
+    scope.launch {
+      searchRepository.resetIndex()
+      withContext(Dispatchers.Main) {
+        Toast.makeText(context, "Search Index Reset", Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
+
+  private fun resetAppData() {
+    scope.launch {
+      searchRepository.resetAppData()
+      withContext(Dispatchers.Main) {
+        Toast.makeText(context, "App Data Reset", Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
+
+  private fun resetOnboarding() {
+    onQueryChange?.invoke("")
+    scope.launch {
+      onboardingManager?.resetOnboarding()
+      withContext(Dispatchers.Main) {
+        Toast.makeText(context, "Onboarding Reset", Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
+
+  private fun launchContact(result: SearchResult.Contact) {
+    try {
+      val intent = Intent(Intent.ACTION_VIEW)
+      val uri =
+        Uri.withAppendedPath(
+          android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
+          result.lookupKey,
+        )
+      intent.data = uri
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      context.startActivity(intent)
+    } catch (e: Exception) {
+      e.printStackTrace()
+      Toast.makeText(context, "Error opening contact", Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  private fun copySnippet(result: SearchResult.Snippet) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText(result.alias, result.content)
+    clipboard.setPrimaryClip(clip)
+    Toast.makeText(context, "Copied ${result.content}", Toast.LENGTH_SHORT).show()
+  }
+
+  companion object {
+    const val ACTION_BIND_WIDGET = "com.searchlauncher.action.BIND_WIDGET"
+    const val ACTION_APPEND_SPACE = "com.searchlauncher.action.APPEND_SPACE"
+    const val ACTION_ADD_WIDGET = "com.searchlauncher.action.ADD_WIDGET"
+    const val ACTION_RESET_INDEX = "com.searchlauncher.RESET_INDEX"
+    const val ACTION_RESET_APP_DATA = "com.searchlauncher.RESET_APP_DATA"
+    const val ACTION_RESET_ONBOARDING = "com.searchlauncher.action.RESET_ONBOARDING"
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -116,9 +116,12 @@ fun SearchScreen(
     remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
       .collectAsState(initial = -1)
   // "Autocomplete suggestions" setting. Gates the network fetch of query suggestions while typing
-  // a shortcut search (e.g. "g cats"). Stored under SEARCH_SHORTCUTS_ENABLED for historical reasons.
+  // a shortcut search (e.g. "g cats"). Stored under SEARCH_SHORTCUTS_ENABLED for historical
+  // reasons.
   val suggestionsEnabled by
-    remember { context.dataStore.data.map { it[PreferencesKeys.SEARCH_SHORTCUTS_ENABLED] ?: false } }
+    remember {
+        context.dataStore.data.map { it[PreferencesKeys.SEARCH_SHORTCUTS_ENABLED] ?: false }
+      }
       .collectAsState(initial = false)
   val minIconSizeSetting by
     remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
@@ -411,12 +414,16 @@ fun SearchScreen(
   LaunchedEffect(hintManager) { hintManager.getHintsFlow().collect { hint -> currentHint = hint } }
 
   // Use SharedPreferences for synchronous read to avoid initial jump
-  val sharedPrefs = remember { context.getSharedPreferences(Prefs.Window.FILE, Context.MODE_PRIVATE) }
+  val sharedPrefs = remember {
+    context.getSharedPreferences(Prefs.Window.FILE, Context.MODE_PRIVATE)
+  }
   val density = LocalDensity.current
   val imeHeightPx = WindowInsets.ime.getBottom(density)
 
   // Read synchronously for initial value
-  var storedKeyboardHeight by remember { mutableStateOf(sharedPrefs.getInt(Prefs.Window.KEYBOARD_HEIGHT, 0)) }
+  var storedKeyboardHeight by remember {
+    mutableStateOf(sharedPrefs.getInt(Prefs.Window.KEYBOARD_HEIGHT, 0))
+  }
 
   val isMultiWindow = (context as? android.app.Activity)?.isInMultiWindowMode == true
 

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.edit
+import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.ui.components.ConsentDialog
@@ -123,16 +124,16 @@ fun SearchScreen(
       .collectAsState(
         initial =
           context
-            .getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
-            .getInt("min_icon_size", PreferencesKeys.getDefaultIconSize(context))
+            .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
+            .getInt(Prefs.Launcher.MIN_ICON_SIZE, PreferencesKeys.getDefaultIconSize(context))
       )
 
   // Sync back to SharedPreferences for faster boot next time
   LaunchedEffect(minIconSizeSetting) {
     context
-      .getSharedPreferences("search_launcher_prefs", Context.MODE_PRIVATE)
+      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
       .edit()
-      .putInt("min_icon_size", minIconSizeSetting)
+      .putInt(Prefs.Launcher.MIN_ICON_SIZE, minIconSizeSetting)
       .apply()
   }
 
@@ -421,12 +422,12 @@ fun SearchScreen(
   LaunchedEffect(hintManager) { hintManager.getHintsFlow().collect { hint -> currentHint = hint } }
 
   // Use SharedPreferences for synchronous read to avoid initial jump
-  val sharedPrefs = remember { context.getSharedPreferences("window_prefs", Context.MODE_PRIVATE) }
+  val sharedPrefs = remember { context.getSharedPreferences(Prefs.Window.FILE, Context.MODE_PRIVATE) }
   val density = LocalDensity.current
   val imeHeightPx = WindowInsets.ime.getBottom(density)
 
   // Read synchronously for initial value
-  var storedKeyboardHeight by remember { mutableStateOf(sharedPrefs.getInt("keyboard_height", 0)) }
+  var storedKeyboardHeight by remember { mutableStateOf(sharedPrefs.getInt(Prefs.Window.KEYBOARD_HEIGHT, 0)) }
 
   val isMultiWindow = (context as? android.app.Activity)?.isInMultiWindowMode == true
 
@@ -436,7 +437,7 @@ fun SearchScreen(
       kotlinx.coroutines.delay(300)
       // If we are still active (didn't get cancelled by new value), save it
       storedKeyboardHeight = imeHeightPx
-      sharedPrefs.edit().putInt("keyboard_height", imeHeightPx).apply()
+      sharedPrefs.edit().putInt(Prefs.Window.KEYBOARD_HEIGHT, imeHeightPx).apply()
     }
   }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -115,6 +115,11 @@ fun SearchScreen(
   val historyLimit by
     remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
       .collectAsState(initial = -1)
+  // "Autocomplete suggestions" setting. Gates the network fetch of query suggestions while typing
+  // a shortcut search (e.g. "g cats"). Stored under SEARCH_SHORTCUTS_ENABLED for historical reasons.
+  val suggestionsEnabled by
+    remember { context.dataStore.data.map { it[PreferencesKeys.SEARCH_SHORTCUTS_ENABLED] ?: false } }
+      .collectAsState(initial = false)
   val minIconSizeSetting by
     remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
 
@@ -293,7 +298,7 @@ fun SearchScreen(
     }
   }
 
-  LaunchedEffect(query) {
+  LaunchedEffect(query, suggestionsEnabled) {
     traceSection("SL:SearchScreen.queryEffect") {
       searchRepository.noteInteractiveSearch(query)
       if (query.isEmpty()) {
@@ -306,7 +311,7 @@ fun SearchScreen(
               .searchApps(
                 query,
                 limit = LIVE_SEARCH_RESULT_LIMIT,
-                includeSuggestions = false,
+                includeSuggestions = suggestionsEnabled,
                 includeSearchShortcuts = true,
               )
               .getOrElse { emptyList() }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -116,26 +116,10 @@ fun SearchScreen(
     remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
       .collectAsState(initial = -1)
   val minIconSizeSetting by
-    remember {
-        context.dataStore.data.map {
-          it[PreferencesKeys.MIN_ICON_SIZE] ?: PreferencesKeys.getDefaultIconSize(context)
-        }
-      }
-      .collectAsState(
-        initial =
-          context
-            .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
-            .getInt(Prefs.Launcher.MIN_ICON_SIZE, PreferencesKeys.getDefaultIconSize(context))
-      )
+    remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
 
-  // Sync back to SharedPreferences for faster boot next time
-  LaunchedEffect(minIconSizeSetting) {
-    context
-      .getSharedPreferences(Prefs.Launcher.FILE, Context.MODE_PRIVATE)
-      .edit()
-      .putInt(Prefs.Launcher.MIN_ICON_SIZE, minIconSizeSetting)
-      .apply()
-  }
+  // Sync back to the boot cache so the next cold start renders at this size immediately.
+  LaunchedEffect(minIconSizeSetting) { MinIconSize.updateCache(context, minIconSizeSetting) }
 
   val historyItems =
     remember(rawHistoryItems, favoriteIds, historyLimit) {

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -62,7 +62,6 @@ import com.searchlauncher.app.ui.onboarding.OnboardingManager
 import com.searchlauncher.app.ui.onboarding.OnboardingStep
 import com.searchlauncher.app.ui.onboarding.TutorialOverlay
 import com.searchlauncher.app.ui.theme.SearchLauncherTheme
-import com.searchlauncher.app.util.CustomActionHandler
 import com.searchlauncher.app.util.MathEvaluator
 import com.searchlauncher.app.util.traceSection
 import kotlinx.coroutines.Dispatchers
@@ -70,7 +69,6 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @Composable
 fun SearchScreen(
@@ -176,6 +174,26 @@ fun SearchScreen(
   // Onboarding Logic
   val onboardingManager = remember { OnboardingManager(context) }
   val completedSteps by onboardingManager.completedSteps.collectAsState(initial = null)
+  val resultLauncher =
+    remember(context, searchRepository, scope, onQueryChange, onAddWidget, onboardingManager) {
+      ResultLauncher(
+        context = context,
+        searchRepository = searchRepository,
+        scope = scope,
+        onQueryChange = onQueryChange,
+        onBindWidgetIntent = { intent ->
+          val activity = context as? MainActivity
+          if (activity != null) {
+            activity.handleWidgetIntent(intent)
+            true
+          } else {
+            false
+          }
+        },
+        onAddWidgetSearch = onAddWidget,
+        onboardingManager = onboardingManager,
+      )
+    }
 
   // Determine current step using derivedStateOf so that intermediate state changes
   // (e.g. completedSteps updating async from DataStore) only trigger recomposition
@@ -758,11 +776,7 @@ fun SearchScreen(
                         )
                         onDismiss()
                       } else {
-                        Toast.makeText(
-                            context,
-                            "Cannot open ${action.label}",
-                            Toast.LENGTH_SHORT,
-                          )
+                        Toast.makeText(context, "Cannot open ${action.label}", Toast.LENGTH_SHORT)
                           .show()
                       }
                     },
@@ -910,28 +924,15 @@ fun SearchScreen(
                               ?.get(1)
                               ?.let { Uri.decode(it) } ?: ""
                           showSnippetDialog = true
-                        } else if (
-                          result is SearchResult.Content &&
-                            result.deepLink ==
-                              "intent:#Intent;action=com.searchlauncher.action.ADD_WIDGET;end"
-                        ) {
-                          onAddWidget()
                         } else {
-                          launchResult(
-                            context,
-                            result,
-                            searchRepository,
-                            scope,
-                            query,
-                            index == 0,
-                            onQueryChange,
-                            onboardingManager = onboardingManager,
-                          )
-                          if (
+                          resultLauncher.launch(result, query = query, wasFirstResult = index == 0)
+                          val keepSearchOpen =
                             result is SearchResult.Content &&
-                              result.deepLink ==
-                                "intent:#Intent;action=com.searchlauncher.action.APPEND_SPACE;end"
-                          ) {
+                              (result.deepLink ==
+                                "intent:#Intent;action=com.searchlauncher.action.APPEND_SPACE;end" ||
+                                result.deepLink ==
+                                  "intent:#Intent;action=com.searchlauncher.action.ADD_WIDGET;end")
+                          if (keepSearchOpen) {
                             // Do nothing (keep search open)
                           } else {
                             onDismiss()
@@ -955,14 +956,7 @@ fun SearchScreen(
             historyLimit = historyLimit,
             minIconSizeSetting = minIconSizeSetting,
             onLaunch = { result ->
-              launchResult(
-                context,
-                result,
-                searchRepository,
-                scope,
-                onQueryChange = onQueryChange,
-                onboardingManager = onboardingManager,
-              )
+              resultLauncher.launch(result, reportUsage = true)
               onDismiss()
             },
             onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result.id) },
@@ -1165,14 +1159,7 @@ fun SearchScreen(
                             onQueryChange(topResult.trigger + " ")
                           }
                         } else {
-                          launchResult(
-                            context,
-                            topResult,
-                            searchRepository,
-                            scope,
-                            onQueryChange = onQueryChange,
-                            onboardingManager = onboardingManager,
-                          )
+                          resultLauncher.launch(topResult, query = query, wasFirstResult = true)
                           onDismiss()
                         }
                       }
@@ -1348,187 +1335,6 @@ fun SearchScreen(
       dismissButton = { TextButton(onClick = { showResetConfirmation = null }) { Text("Cancel") } },
     )
   }
-}
-
-private fun launchResult(
-  context: Context,
-  result: SearchResult,
-  searchRepository: SearchRepository,
-  scope: kotlinx.coroutines.CoroutineScope,
-  query: String = "",
-  wasFirstResult: Boolean = false,
-  onQueryChange: ((String) -> Unit)? = null,
-  onboardingManager: OnboardingManager? = null,
-) {
-  when (result) {
-    is SearchResult.App -> {
-      val launchIntent = context.packageManager.getLaunchIntentForPackage(result.packageName)
-      launchIntent?.let {
-        it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(it)
-      }
-    }
-    is SearchResult.Content -> {
-      if (result.deepLink?.startsWith("calculator://copy") == true) {
-        val textToCopy = Uri.parse(result.deepLink).getQueryParameter("text") ?: result.title
-        val clipboard =
-          context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-        val clip = android.content.ClipData.newPlainText("Calculator Result", textToCopy)
-        clipboard.setPrimaryClip(clip)
-        Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
-        return
-      }
-      if (result.deepLink?.startsWith("timer://set") == true) {
-        val uri = Uri.parse(result.deepLink)
-        val seconds = uri.getQueryParameter("seconds")?.toIntOrNull() ?: return
-        val name = uri.getQueryParameter("name")
-        val timerIntent =
-          Intent(android.provider.AlarmClock.ACTION_SET_TIMER).apply {
-            putExtra(android.provider.AlarmClock.EXTRA_LENGTH, seconds)
-            if (name != null) putExtra(android.provider.AlarmClock.EXTRA_MESSAGE, name)
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-          }
-        try {
-          context.startActivity(timerIntent)
-        } catch (e: android.content.ActivityNotFoundException) {
-          Toast.makeText(context, "No timer app found", Toast.LENGTH_SHORT).show()
-        }
-        return
-      }
-      result.deepLink?.let { deepLink ->
-        try {
-          val intent =
-            if (deepLink.startsWith("intent:")) {
-              Intent.parseUri(deepLink, Intent.URI_INTENT_SCHEME)
-            } else {
-              Intent(Intent.ACTION_VIEW, Uri.parse(deepLink))
-            }
-
-          if (intent.action == "com.searchlauncher.action.BIND_WIDGET") {
-            (context as? MainActivity)?.handleWidgetIntent(intent)
-              ?: run {
-                Toast.makeText(
-                    context,
-                    "Cannot bind widget: Activity not found",
-                    Toast.LENGTH_SHORT,
-                  )
-                  .show()
-              }
-          } else if (intent.action == "com.searchlauncher.action.APPEND_SPACE") {
-            onQueryChange?.invoke(query + " ")
-          } else if (intent.action == "com.searchlauncher.RESET_INDEX") {
-            scope.launch {
-              searchRepository.resetIndex()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Search Index Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (intent.action == "com.searchlauncher.RESET_APP_DATA") {
-            scope.launch {
-              searchRepository.resetAppData()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "App Data Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (intent.action == "com.searchlauncher.action.RESET_ONBOARDING") {
-            onQueryChange?.invoke("")
-            scope.launch {
-              onboardingManager?.resetOnboarding()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Onboarding Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (CustomActionHandler.handleAction(context, intent)) {
-            // Handled
-          } else {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            context.startActivity(intent)
-          }
-        } catch (e: Exception) {
-          e.printStackTrace()
-          Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
-        }
-      }
-    }
-    is SearchResult.Shortcut -> {
-      try {
-        val uri = result.intentUri
-        if (uri.startsWith("shortcut://")) {
-          val parts = uri.substring("shortcut://".length).split("/")
-          if (parts.size == 2) {
-            val pkg = parts[0]
-            val id = parts[1]
-            val launcherApps =
-              context.getSystemService(Context.LAUNCHER_APPS_SERVICE)
-                as android.content.pm.LauncherApps
-            launcherApps.startShortcut(pkg, id, null, null, android.os.Process.myUserHandle())
-          }
-        } else {
-          val intent = Intent.parseUri(uri, Intent.URI_INTENT_SCHEME)
-          if (intent.action == "com.searchlauncher.RESET_INDEX") {
-            scope.launch {
-              searchRepository.resetIndex()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Search Index Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (intent.action == "com.searchlauncher.RESET_APP_DATA") {
-            scope.launch {
-              searchRepository.resetAppData()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "App Data Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (intent.action == "com.searchlauncher.action.RESET_ONBOARDING") {
-            onQueryChange?.invoke("")
-            scope.launch {
-              onboardingManager?.resetOnboarding()
-              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Onboarding Reset", Toast.LENGTH_SHORT).show()
-              }
-            }
-          } else if (CustomActionHandler.handleAction(context, intent)) {
-            // Handled
-          } else {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            context.startActivity(intent)
-          }
-        }
-      } catch (e: Exception) {
-        e.printStackTrace()
-        Toast.makeText(context, "Error launching shortcut", Toast.LENGTH_SHORT).show()
-      }
-    }
-    is SearchResult.SearchIntent -> {
-      // Handled in UI
-    }
-    is SearchResult.Contact -> {
-      try {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val uri =
-          Uri.withAppendedPath(
-            android.provider.ContactsContract.Contacts.CONTENT_LOOKUP_URI,
-            result.lookupKey,
-          )
-        intent.data = uri
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-      } catch (e: Exception) {
-        e.printStackTrace()
-        Toast.makeText(context, "Error opening contact", Toast.LENGTH_SHORT).show()
-      }
-    }
-    is SearchResult.Snippet -> {
-      val clipboard =
-        context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-      val clip = android.content.ClipData.newPlainText(result.alias, result.content)
-      clipboard.setPrimaryClip(clip)
-      Toast.makeText(context, "Copied ${result.content}", Toast.LENGTH_SHORT).show()
-    }
-  }
-
-  // Usage reporting
-  searchRepository.reportUsageAsync(result.namespace, result.id, query, wasFirstResult)
 }
 
 internal fun Drawable.toImageBitmap(): ImageBitmap? {

--- a/app/src/main/java/com/searchlauncher/app/ui/components/AppActionsMenu.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/AppActionsMenu.kt
@@ -1,0 +1,84 @@
+package com.searchlauncher.app.ui.components
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.searchlauncher.app.data.SearchResult
+
+@Composable
+fun AppActionsMenuItems(
+  result: SearchResult,
+  isFavorite: Boolean,
+  onToggleFavorite: (() -> Unit)?,
+  onCloseMenu: () -> Unit,
+  favoriteAddLabel: String = "Add to Favorites",
+  favoriteRemoveLabel: String = "Remove from Favorites",
+  showAppInfo: Boolean = true,
+  showUninstall: Boolean = false,
+  onClearSearchResults: (() -> Unit)? = null,
+) {
+  val context = LocalContext.current
+
+  if (onToggleFavorite != null) {
+    DropdownMenuItem(
+      text = { Text(if (isFavorite) favoriteRemoveLabel else favoriteAddLabel) },
+      onClick = {
+        onToggleFavorite()
+        onCloseMenu()
+      },
+      leadingIcon = {
+        Icon(
+          imageVector = if (isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
+          contentDescription = null,
+        )
+      },
+    )
+  }
+
+  if (result is SearchResult.App && showAppInfo) {
+    DropdownMenuItem(
+      text = { Text("App Info") },
+      onClick = {
+        try {
+          val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+          intent.data = Uri.parse("package:${result.packageName}")
+          intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          context.startActivity(intent)
+        } catch (e: Exception) {
+          Toast.makeText(context, "Cannot open App Info", Toast.LENGTH_SHORT).show()
+        }
+        onCloseMenu()
+      },
+      leadingIcon = { Icon(Icons.Default.Info, contentDescription = null) },
+    )
+  }
+
+  if (result is SearchResult.App && showUninstall) {
+    DropdownMenuItem(
+      text = { Text("Uninstall") },
+      onClick = {
+        try {
+          val packageUri = Uri.fromParts("package", result.packageName, null)
+          val intent = Intent(Intent.ACTION_DELETE, packageUri)
+          intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          context.startActivity(intent)
+          onClearSearchResults?.invoke()
+        } catch (e: Exception) {
+          Toast.makeText(context, "Cannot start uninstall: ${e.message}", Toast.LENGTH_SHORT).show()
+        }
+        onCloseMenu()
+      },
+      leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+    )
+  }
+}

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -1,8 +1,5 @@
 package com.searchlauncher.app.ui.components
 
-import android.content.Intent
-import android.net.Uri
-import android.widget.Toast
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -11,9 +8,6 @@ import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -23,7 +17,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
@@ -50,7 +43,6 @@ fun FavoritesRow(
 
   val haptic = LocalHapticFeedback.current
   val density = LocalDensity.current
-  val context = LocalContext.current
 
   val minIconSizeDp = minIconSizeSetting.dp
   val dividerGapDp = 16.dp
@@ -319,33 +311,13 @@ fun FavoritesRow(
             ) {
               val isFavorite = favorites.any { it.id == result.id }
 
-              DropdownMenuItem(
-                text = { Text(if (isFavorite) "Remove from Favorites" else "Add Favorite") },
-                onClick = {
-                  onToggleFavorite(result)
-                  showMenuForIndex = null
-                },
-                leadingIcon = { Icon(Icons.Default.Star, contentDescription = null) },
+              AppActionsMenuItems(
+                result = result,
+                isFavorite = isFavorite,
+                onToggleFavorite = { onToggleFavorite(result) },
+                onCloseMenu = { showMenuForIndex = null },
+                favoriteAddLabel = "Add Favorite",
               )
-
-              if (result is SearchResult.App) {
-                DropdownMenuItem(
-                  text = { Text("App Info") },
-                  onClick = {
-                    try {
-                      val intent =
-                        Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                      intent.data = Uri.parse("package:${result.packageName}")
-                      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                      context.startActivity(intent)
-                    } catch (e: Exception) {
-                      Toast.makeText(context, "Cannot open App Info", Toast.LENGTH_SHORT).show()
-                    }
-                    showMenuForIndex = null
-                  },
-                  leadingIcon = { Icon(Icons.Default.Info, contentDescription = null) },
-                )
-              }
             }
           }
         }

--- a/app/src/main/java/com/searchlauncher/app/ui/components/SearchResultItem.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/SearchResultItem.kt
@@ -1,10 +1,6 @@
 package com.searchlauncher.app.ui.components
 
-import android.content.Context
-import android.content.Intent
 import android.graphics.drawable.Drawable
-import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -16,10 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -64,9 +57,8 @@ fun SearchResultItem(
     (context.applicationContext as SearchLauncherApp).searchRepository
   }
   var iconState by remember(result.id) { mutableStateOf<Drawable?>(result.icon) }
-  var contactChatActions by remember(result.id) {
-    mutableStateOf<List<ContactChatAction>>(emptyList())
-  }
+  var contactChatActions by
+    remember(result.id) { mutableStateOf<List<ContactChatAction>>(emptyList()) }
 
   LaunchedEffect(result.id) {
     if (iconState == null) {
@@ -236,10 +228,7 @@ fun SearchResultItem(
 
         if (result is SearchResult.App) {
           Box(modifier = Modifier.padding(start = 8.dp)) {
-            IconButton(
-              onClick = { showAppActionsMenu = true },
-              modifier = Modifier.size(40.dp),
-            ) {
+            IconButton(onClick = { showAppActionsMenu = true }, modifier = Modifier.size(40.dp)) {
               Icon(
                 imageVector = Icons.Default.MoreVert,
                 contentDescription = "More app actions",
@@ -253,13 +242,13 @@ fun SearchResultItem(
               modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant),
               properties = PopupProperties(focusable = false),
             ) {
-              AppMenuItems(
+              AppActionsMenuItems(
                 result = result,
-                context = context,
                 isFavorite = isFavorite,
                 onToggleFavorite = onToggleFavorite,
-                onClearSearchResults = onClearSearchResults,
                 onCloseMenu = { showAppActionsMenu = false },
+                showUninstall = true,
+                onClearSearchResults = onClearSearchResults,
               )
             }
           }
@@ -338,34 +327,23 @@ fun SearchResultItem(
           }
 
           if (onToggleFavorite != null) {
-            DropdownMenuItem(
-              text = { Text(if (isFavorite) "Remove from Favorites" else "Add to Favorites") },
-              onClick = {
-                onToggleFavorite()
-                showMenu = false
-              },
-              leadingIcon = {
-                Icon(
-                  imageVector =
-                    if (isFavorite) {
-                      Icons.Default.Star
-                    } else {
-                      Icons.Default.StarBorder
-                    },
-                  contentDescription = null,
-                )
-              },
+            AppActionsMenuItems(
+              result = result,
+              isFavorite = isFavorite,
+              onToggleFavorite = onToggleFavorite,
+              onCloseMenu = { showMenu = false },
+              showAppInfo = false,
             )
           }
 
           if (result is SearchResult.App) {
-            AppMenuItems(
+            AppActionsMenuItems(
               result = result,
-              context = context,
               isFavorite = isFavorite,
               onToggleFavorite = null,
-              onClearSearchResults = onClearSearchResults,
               onCloseMenu = { showMenu = false },
+              showUninstall = true,
+              onClearSearchResults = onClearSearchResults,
             )
           }
 
@@ -383,69 +361,6 @@ fun SearchResultItem(
       }
     }
   }
-}
-
-@Composable
-private fun AppMenuItems(
-  result: SearchResult.App,
-  context: Context,
-  isFavorite: Boolean,
-  onToggleFavorite: (() -> Unit)?,
-  onClearSearchResults: (() -> Unit)?,
-  onCloseMenu: () -> Unit,
-) {
-  if (onToggleFavorite != null) {
-    DropdownMenuItem(
-      text = { Text(if (isFavorite) "Remove from Favorites" else "Add to Favorites") },
-      onClick = {
-        onToggleFavorite()
-        onCloseMenu()
-      },
-      leadingIcon = {
-        Icon(
-          imageVector =
-            if (isFavorite) {
-              Icons.Default.Star
-            } else {
-              Icons.Default.StarBorder
-            },
-          contentDescription = null,
-        )
-      },
-    )
-  }
-
-  DropdownMenuItem(
-    text = { Text("App Info") },
-    onClick = {
-      try {
-        val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-        intent.data = Uri.parse("package:${result.packageName}")
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-      } catch (e: Exception) {
-        Toast.makeText(context, "Cannot open App Info", Toast.LENGTH_SHORT).show()
-      }
-      onCloseMenu()
-    },
-    leadingIcon = { Icon(Icons.Default.Info, contentDescription = null) },
-  )
-  DropdownMenuItem(
-    text = { Text("Uninstall") },
-    onClick = {
-      try {
-        val packageUri = Uri.fromParts("package", result.packageName, null)
-        val intent = Intent(Intent.ACTION_DELETE, packageUri)
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-        onClearSearchResults?.invoke()
-      } catch (e: Exception) {
-        Toast.makeText(context, "Cannot start uninstall: ${e.message}", Toast.LENGTH_SHORT).show()
-      }
-      onCloseMenu()
-    },
-    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
-  )
 }
 
 @Composable

--- a/app/src/test/java/com/searchlauncher/app/data/ContactActionsRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/ContactActionsRepositoryTest.kt
@@ -133,11 +133,7 @@ class ContactActionsRepositoryTest {
   @Test
   fun `dataId opens the specific data row scoped to the package`() {
     val action =
-      ContactChatAction(
-        label = "Telegram",
-        packageName = "org.telegram.messenger",
-        dataId = 99L,
-      )
+      ContactChatAction(label = "Telegram", packageName = "org.telegram.messenger", dataId = 99L)
     val intents = repo.buildContactActionIntents(contact(), action)
 
     val dataIntent = intents.first { it.data?.toString()?.endsWith("/99") == true }

--- a/app/src/test/java/com/searchlauncher/app/data/ContactActionsRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/ContactActionsRepositoryTest.kt
@@ -1,0 +1,187 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class ContactActionsRepositoryTest {
+
+  private lateinit var repo: ContactActionsRepository
+
+  @Before
+  fun setUp() {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    repo = ContactActionsRepository(context)
+  }
+
+  private fun contact() =
+    SearchResult.Contact(
+      id = "lookup123/42",
+      title = "Jane Doe",
+      subtitle = null,
+      icon = null,
+      lookupKey = "lookup123",
+      contactId = 42L,
+      photoUri = null,
+    )
+
+  // --- chatPackageFromMimeType ---
+
+  @Test
+  fun `detects Telegram from data mime type`() {
+    val mime = "vnd.android.cursor.item/vnd.org.telegram.messenger.android.profile"
+    assertEquals("org.telegram.messenger", repo.chatPackageFromMimeType(mime))
+  }
+
+  @Test
+  fun `detects WhatsApp from data mime type`() {
+    val mime = "vnd.android.cursor.item/vnd.com.whatsapp.profile"
+    assertEquals("com.whatsapp", repo.chatPackageFromMimeType(mime))
+  }
+
+  @Test
+  fun `detects Signal from data mime type`() {
+    val mime = "vnd.android.cursor.item/vnd.org.thoughtcrime.securesms.profile"
+    assertEquals("org.thoughtcrime.securesms", repo.chatPackageFromMimeType(mime))
+  }
+
+  @Test
+  fun `mime detection is case insensitive`() {
+    val mime = "VND.ANDROID.CURSOR.ITEM/VND.ORG.TELEGRAM.MESSENGER.ANDROID.PROFILE"
+    assertEquals("org.telegram.messenger", repo.chatPackageFromMimeType(mime))
+  }
+
+  @Test
+  fun `non-chat mime types return null`() {
+    assertNull(repo.chatPackageFromMimeType("vnd.android.cursor.item/phone_v2"))
+    assertNull(repo.chatPackageFromMimeType("vnd.android.cursor.item/email_v2"))
+  }
+
+  // --- buildContactActionIntents ---
+
+  @Test
+  fun `call action dials the number then falls back to the contact`() {
+    val action =
+      ContactChatAction(
+        label = "Call",
+        packageName = ContactActionsRepository.CALL_ACTION_KEY,
+        phoneNumber = "+1 555-1234",
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    assertEquals(2, intents.size)
+    assertEquals(Intent.ACTION_DIAL, intents[0].action)
+    assertEquals("tel", intents[0].data?.scheme)
+    // The list always ends with a generic contact-lookup fallback.
+    assertEquals(Intent.ACTION_VIEW, intents.last().action)
+  }
+
+  @Test
+  fun `sms action uses smsto sendto`() {
+    val action =
+      ContactChatAction(
+        label = "SMS",
+        packageName = ContactActionsRepository.SMS_ACTION_KEY,
+        phoneNumber = "5551234",
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    assertEquals(Intent.ACTION_SENDTO, intents[0].action)
+    assertEquals("smsto", intents[0].data?.scheme)
+  }
+
+  @Test
+  fun `email action uses mailto sendto`() {
+    val action =
+      ContactChatAction(
+        label = "Email",
+        packageName = ContactActionsRepository.EMAIL_ACTION_KEY,
+        phoneNumber = "jane@example.com",
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    assertEquals(Intent.ACTION_SENDTO, intents[0].action)
+    assertEquals("mailto", intents[0].data?.scheme)
+  }
+
+  @Test
+  fun `whatsapp action targets wa_me with a digits-only number`() {
+    val action =
+      ContactChatAction(
+        label = "WhatsApp",
+        packageName = ContactActionsRepository.WHATSAPP_PACKAGE,
+        phoneNumber = "+1 (555) 123-4567",
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    val waIntent = intents.first { it.data?.toString()?.startsWith("https://wa.me/") == true }
+    assertEquals("https://wa.me/15551234567", waIntent.data.toString())
+    assertEquals(ContactActionsRepository.WHATSAPP_PACKAGE, waIntent.`package`)
+  }
+
+  @Test
+  fun `dataId opens the specific data row scoped to the package`() {
+    val action =
+      ContactChatAction(
+        label = "Telegram",
+        packageName = "org.telegram.messenger",
+        dataId = 99L,
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    val dataIntent = intents.first { it.data?.toString()?.endsWith("/99") == true }
+    assertEquals(Intent.ACTION_VIEW, dataIntent.action)
+    assertEquals("org.telegram.messenger", dataIntent.`package`)
+  }
+
+  @Test
+  fun `falls back to the contact lookup when the action has no actionable data`() {
+    // Call key but no phone number, and no dataId: only the generic fallback remains.
+    val action =
+      ContactChatAction(
+        label = "Call",
+        packageName = ContactActionsRepository.CALL_ACTION_KEY,
+        phoneNumber = null,
+      )
+    val intents = repo.buildContactActionIntents(contact(), action)
+
+    assertEquals(1, intents.size)
+    assertEquals(Intent.ACTION_VIEW, intents[0].action)
+    assertEquals(ContactActionsRepository.CALL_ACTION_KEY, intents[0].`package`)
+    assertTrue(intents[0].data.toString().contains("lookup123"))
+  }
+
+  // --- orderByLastUsed ---
+
+  private fun action(pkg: String) = ContactChatAction(label = pkg, packageName = pkg)
+
+  @Test
+  fun `last used ordering keeps order when there is no last package`() {
+    val actions = listOf(action("a"), action("b"), action("c"))
+    assertEquals(actions, repo.orderByLastUsed(actions, null))
+  }
+
+  @Test
+  fun `last used ordering moves the last package to the front, others stable`() {
+    val actions = listOf(action("a"), action("b"), action("c"))
+    val ordered = repo.orderByLastUsed(actions, "c")
+    assertEquals(listOf("c", "a", "b"), ordered.map { it.packageName })
+  }
+
+  @Test
+  fun `last used ordering leaves order unchanged when last package is absent`() {
+    val actions = listOf(action("a"), action("b"))
+    assertEquals(actions, repo.orderByLastUsed(actions, "zzz"))
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -173,14 +173,10 @@ class SearchRepositoryTest {
 
   @Test
   fun `contact chat mime detection supports telegram org package`() {
-    val method =
-      SearchRepository::class.java.getDeclaredMethod("chatPackageFromMimeType", String::class.java)
-    method.isAccessible = true
-
+    val contactActionsRepository = ContactActionsRepository(context)
     val packageName =
-      method.invoke(
-        repository,
-        "vnd.android.cursor.item/vnd.org.telegram.messenger.android.profile",
+      contactActionsRepository.chatPackageFromMimeType(
+        "vnd.android.cursor.item/vnd.org.telegram.messenger.android.profile"
       )
 
     assertEquals("org.telegram.messenger", packageName)


### PR DESCRIPTION
Completes the SearchLauncher simplification plan (see `REFACTOR_PLAN.md`). Behavior-preserving structural work plus two bug fixes found along the way. `./gradlew testDebugUnitTest assembleDebug` passes at every commit.

## Headline
- **`SearchRepository.kt`: 3,164 → 1,971 lines (−38%)**, broken into focused, independently-testable modules.

## What's in here

**Phase 3 — split search/index responsibilities**
- Extracted `AppIndexer`, `ShortcutIndexer` (dynamic/static/custom), `ContactIndexer`, `SnippetIndexer` as pure document builders. The repository keeps AppSearch persistence + orchestration; the "abort on `DeadObjectException`" semantics are preserved via a nullable return.

**Phase 4 — normalize storage**
- Inventoried every SharedPreferences/DataStore store and documented an ownership principle (DataStore = durable user settings; SharedPreferences = device-local/internal/transient). Conclusion: nothing needs relocating.
- Centralized all SharedPreferences file/key names into a single `Prefs` registry (byte-identical values, no data migration).
- Encapsulated the `min_icon_size` DataStore-plus-boot-cache into `MinIconSize`, removing duplicated default logic from `SearchScreen`.

**Phase 2 — contact action tests**
- Extracted `buildContactActionIntents` and `orderByLastUsed` as pure functions and covered them, plus `chatPackageFromMimeType`, in `ContactActionsRepositoryTest` (14 Robolectric cases).

## Bug fixes
- **App-list crash** (`IllegalArgumentException: Key … was already used`): a package with multiple launcher activities (e.g. Tasker) produced duplicate package ids. Latent before this work; fixed at the source in `AppIndexer` plus a defensive dedupe in `updateAppsCache`.
- **Autocomplete suggestions never appeared**: the "Autocomplete suggestions" toggle wrote a pref the search path never read (`includeSuggestions` was hard-coded `false`). Now gated on the setting.

## Notes
- The optional Phase 1 "rows delegate actions" item was intentionally dropped (rationale in `REFACTOR_PLAN.md`) — in Compose it would add indirection to working UI without real benefit.
- Base is `joepio/main`; this bundles the prior "Major refactor" commit plus the 6 commits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)