### PR TITLE
Set up cloud dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+SearchLauncher is a single native **Android** app (Kotlin + Jetpack Compose + Gradle). There is **no backend/server, database, or docker service** — everything runs on-device. "Running the app" means building an APK and running it on an Android emulator.
+
+### Toolchain (already provisioned in the VM snapshot)
+- **JDK 17** and the **Android SDK** (cmdline-tools, `platform-tools`, `platforms;android-36`, `build-tools;36.0.0`, `emulator`) are pre-installed.
+- `~/.bashrc` exports `JAVA_HOME` (JDK 17) and `ANDROID_HOME`/`ANDROID_SDK_ROOT` (`~/Android/Sdk`) and adds their `bin`/`platform-tools`/`emulator` dirs to `PATH`. New shells pick these up automatically.
+- `~/.gradle/gradle.properties` pins `org.gradle.java.home` to JDK 17, so Gradle builds on JDK 17 even if a shell's `java` resolves to the system JDK 21. Do **not** rely on the system default `java` (it is 21; the project needs 17).
+
+### Standard commands (see `README.md`)
+Run from the repo root with the Gradle wrapper:
+- Lint/format check: `./gradlew spotlessCheck` (auto-fix with `./gradlew spotlessApply`). CI enforces this.
+- Unit tests: `./gradlew test` (Robolectric/MockK/JUnit).
+- Build debug APK: `./gradlew assembleDebug`; install to a running device/emulator: `./gradlew installDebug`.
+
+### Running end-to-end on an emulator (important, non-obvious)
+The VM has **no KVM** (`/dev/kvm` is absent), so the emulator must run in **software (TCG) mode**. This works but is slow, and requires the following to be usable:
+
+- **Use an AOSP (`default`) system image, not `google_apis`.** The Google APIs image thrashes under software emulation (guest load ~40, never settles, persistent "isn't responding" ANR dialogs). An AOSP image (e.g. `system-images;android-30;default;x86_64`) is far lighter and settles to a responsive state. An AVD named `aosp30` is already created in the snapshot.
+- Launch flags that work: `emulator -avd aosp30 -no-snapshot -no-audio -no-boot-anim -gpu swiftshader_indirect -accel off -qemu -m 3072` (run it in a persistent tmux session; the host stays near load ~1 while the guest emulates).
+- Boot and the app's first-run **AppSearch indexing** spike CPU and can trigger system "isn't responding" (ANR) dialogs. Mitigation: `adb shell settings put global hide_error_dialogs 1`, then `adb reboot` once to clear any stuck ANR dialog. After the guest settles (`adb shell cat /proc/loadavg` 1‑min avg below ~3) the UI is responsive. Disable animations: `adb shell settings put global {window,transition,animator}_*_scale 0`.
+- `adb shell input tap X Y` uses **device pixel** coordinates (this AVD is 1080x2400), **not** the scaled screenshot coordinates. Get exact element bounds with `adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml`.
+- SearchLauncher is a launcher app: on first launch it shows one-time onboarding dialogs ("Set as Default Launcher?", "Privacy choices") and may prompt for permissions. Pre-grant runtime perms to avoid prompts: `adb shell pm grant com.searchlauncher.app android.permission.READ_CONTACTS` (and `RECORD_AUDIO`). Launch the search UI directly with `adb shell am start -n com.searchlauncher.app/.ui.MainActivity`.
+- Core "hello world": type a query (e.g. `settings`) into the search bar and tap the matching app result — SearchLauncher launches the target app (verified with the Android Settings app).
+
+### Notes
+- Release signing is optional; debug builds/tests/emulator runs need no signing keystore or secrets.
+- Gradle dependencies are fetched on the first build (no separate install step). The startup update script only runs `./gradlew --version` to warm the wrapper.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for the SearchLauncher Android app in the Cursor Cloud VM and documents the non-obvious steps for future agents.

This PR only adds `AGENTS.md`. The toolchain itself (JDK 17, Android SDK, emulator, an `aosp30` AVD) is installed into the VM snapshot, and the startup update script is `./gradlew --version` (warms the Gradle wrapper).

## Environment set up

- Installed **JDK 17** (project requires 17; the VM shipped with JDK 21) and pinned it for Gradle via `~/.gradle/gradle.properties` (`org.gradle.java.home`).
- Installed the **Android SDK**: cmdline-tools, `platform-tools`, `platforms;android-36`, `build-tools;36.0.0`, `emulator`, and an AOSP `system-images;android-30;default;x86_64` image.
- Exported `JAVA_HOME` / `ANDROID_HOME` in `~/.bashrc` (persisted in the snapshot).

## Verified end to end

| Task | Command | Result |
| --- | --- | --- |
| Lint | `./gradlew spotlessCheck` | PASS |
| Unit tests | `./gradlew test` | PASS |
| Build | `./gradlew assembleDebug` | BUILD SUCCESSFUL (`app-debug.apk`) |
| Run (emulator) | `./gradlew installDebug` equivalent via `adb install` + launch | App runs |

**Hello-world:** installed the app on a software-mode Android emulator (no KVM in the VM), searched `settings` in SearchLauncher, tapped the result, and the Android **Settings** app launched.

### Key gotcha captured in AGENTS.md
The VM has no `/dev/kvm`, so the emulator runs in software (TCG) mode. A `google_apis` image thrashes and ANRs endlessly under emulation; an **AOSP `default` image** settles and is usable. AGENTS.md documents the working launch flags, ANR mitigation (`hide_error_dialogs` + one reboot), and that `adb input tap` uses device-pixel coordinates.

## Demo

[searchlauncher_search_and_launch_demo.mp4](https://cursor.com/agents/bc-9734e813-7a61-422e-aea4-85891fe1d904/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearchlauncher_search_and_launch_demo.mp4)

[SearchLauncher search results](https://cursor.com/agents/bc-9734e813-7a61-422e-aea4-85891fe1d904/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearchlauncher_search_results.png)
[Settings launched from SearchLauncher](https://cursor.com/agents/bc-9734e813-7a61-422e-aea4-85891fe1d904/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearchlauncher_settings_launched.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9734e813-7a61-422e-aea4-85891fe1d904?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9734e813-7a61-422e-aea4-85891fe1d904&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

