### PR TITLE
Force desktop CSS viewport for Desktop view on phones

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -804,7 +804,8 @@ private fun BrowserScreen(
                     refreshPageBackground(view, allowWhiteFallback = true)
                     activeTab.url = url
                     activeTab.title = view.title
-                    // Sites (and late-injected tags) can rewrite the viewport during load; re-assert
+                    // Sites (and late-injected tags) can rewrite the viewport during load;
+                    // re-assert
                     // the desktop width after the document is complete.
                     view.applyDesktopViewport(activeTab.desktopMode)
                     // Keep the snapshot up until the fully loaded page (CSS and fonts included)
@@ -1431,12 +1432,13 @@ private fun WebView.setDesktopMode(enabled: Boolean, phoneUserAgent: String?) {
 /** Chromium's default desktop layout width when Request Desktop Site ignores viewport meta. */
 internal const val DESKTOP_VIEWPORT_WIDTH = 980
 
-internal fun desktopViewportMetaContent(width: Int = DESKTOP_VIEWPORT_WIDTH): String = "width=$width"
+internal fun desktopViewportMetaContent(width: Int = DESKTOP_VIEWPORT_WIDTH): String =
+  "width=$width"
 
 /**
- * Force a desktop CSS viewport on small devices. UA spoofing alone is not enough: responsive
- * sites with `width=device-width` still match phone media queries. WebView has no API to ignore
- * viewport meta like Chrome RDS, so we rewrite (or create) the tag to a fixed desktop width.
+ * Force a desktop CSS viewport on small devices. UA spoofing alone is not enough: responsive sites
+ * with `width=device-width` still match phone media queries. WebView has no API to ignore viewport
+ * meta like Chrome RDS, so we rewrite (or create) the tag to a fixed desktop width.
  */
 private fun WebView.applyDesktopViewport(enabled: Boolean) {
   if (!enabled) return

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -1507,28 +1507,15 @@ private val DESKTOP_VIEWPORT_SCRIPT =
   """
   (() => {
     const content = '${desktopViewportMetaContent()}';
-    const ensure = () => {
-      if (!document.documentElement) return null;
-      let meta = document.querySelector('meta[name="viewport"]');
-      if (!meta) {
-        meta = document.createElement('meta');
-        meta.setAttribute('name', 'viewport');
-        (document.head || document.documentElement).appendChild(meta);
-      }
-      if (meta.getAttribute('content') !== content) {
-        meta.setAttribute('content', content);
-      }
-      return meta;
-    };
-    const meta = ensure();
-    if (!meta || document.documentElement.dataset.slDesktopViewport === '1') return;
-    document.documentElement.dataset.slDesktopViewport = '1';
-    new MutationObserver(ensure).observe(meta, {
-      attributes: true,
-      attributeFilter: ['content'],
-    });
-    if (document.head) {
-      new MutationObserver(ensure).observe(document.head, { childList: true });
+    if (!document.documentElement) return;
+    let meta = document.querySelector('meta[name="viewport"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.setAttribute('name', 'viewport');
+      (document.head || document.documentElement).appendChild(meta);
+    }
+    if (meta.getAttribute('content') !== content) {
+      meta.setAttribute('content', content);
     }
   })()
   """

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -795,12 +795,18 @@ private fun BrowserScreen(
                     } else {
                       refreshPageBackground(view, allowWhiteFallback = false)
                     }
+                    // Apply as soon as the document is usable so responsive CSS doesn't briefly
+                    // lay out at the phone width before onPageFinished.
+                    view.applyDesktopViewport(activeTab.desktopMode)
                   }
 
                   override fun onPageFinished(view: WebView, url: String) {
                     refreshPageBackground(view, allowWhiteFallback = true)
                     activeTab.url = url
                     activeTab.title = view.title
+                    // Sites (and late-injected tags) can rewrite the viewport during load; re-assert
+                    // the desktop width after the document is complete.
+                    view.applyDesktopViewport(activeTab.desktopMode)
                     // Keep the snapshot up until the fully loaded page (CSS and fonts included)
                     // has actually been drawn, so tab switches never flash a half-styled page.
                     view.postVisualStateCallback(
@@ -1416,8 +1422,25 @@ private fun WebView.applySiteSettings(siteSettings: BrowserSiteSettings) {
 private fun WebView.setDesktopMode(enabled: Boolean, phoneUserAgent: String?) {
   settings.userAgentString =
     if (enabled) desktopUserAgent(phoneUserAgent ?: settings.userAgentString) else phoneUserAgent
+  // Wide viewport + overview mode let a forced desktop layout width (see applyDesktopViewport)
+  // paint at ~980 CSS px and zoom to fit the physical screen on phones.
   settings.useWideViewPort = enabled
   settings.loadWithOverviewMode = enabled
+}
+
+/** Chromium's default desktop layout width when Request Desktop Site ignores viewport meta. */
+internal const val DESKTOP_VIEWPORT_WIDTH = 980
+
+internal fun desktopViewportMetaContent(width: Int = DESKTOP_VIEWPORT_WIDTH): String = "width=$width"
+
+/**
+ * Force a desktop CSS viewport on small devices. UA spoofing alone is not enough: responsive
+ * sites with `width=device-width` still match phone media queries. WebView has no API to ignore
+ * viewport meta like Chrome RDS, so we rewrite (or create) the tag to a fixed desktop width.
+ */
+private fun WebView.applyDesktopViewport(enabled: Boolean) {
+  if (!enabled) return
+  evaluateJavascript(DESKTOP_VIEWPORT_SCRIPT, null)
 }
 
 internal fun desktopUserAgent(phoneUserAgent: String): String =
@@ -1475,6 +1498,36 @@ private const val PAGE_BACKGROUND_SCRIPT =
     const body = document.body ? getComputedStyle(document.body).backgroundColor : transparent;
     if (body && body !== transparent) return body;
     return getComputedStyle(document.documentElement).backgroundColor;
+  })()
+  """
+
+private val DESKTOP_VIEWPORT_SCRIPT =
+  """
+  (() => {
+    const content = '${desktopViewportMetaContent()}';
+    const ensure = () => {
+      if (!document.documentElement) return null;
+      let meta = document.querySelector('meta[name="viewport"]');
+      if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'viewport');
+        (document.head || document.documentElement).appendChild(meta);
+      }
+      if (meta.getAttribute('content') !== content) {
+        meta.setAttribute('content', content);
+      }
+      return meta;
+    };
+    const meta = ensure();
+    if (!meta || document.documentElement.dataset.slDesktopViewport === '1') return;
+    document.documentElement.dataset.slDesktopViewport = '1';
+    new MutationObserver(ensure).observe(meta, {
+      attributes: true,
+      attributeFilter: ['content'],
+    });
+    if (document.head) {
+      new MutationObserver(ensure).observe(document.head, { childList: true });
+    }
   })()
   """
 

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserNavigationTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserNavigationTest.kt
@@ -48,6 +48,13 @@ class BrowserNavigationTest {
   }
 
   @Test
+  fun desktopViewportMetaUsesChromiumDefaultWidth() {
+    assertEquals(980, DESKTOP_VIEWPORT_WIDTH)
+    assertEquals("width=980", desktopViewportMetaContent())
+    assertEquals("width=1280", desktopViewportMetaContent(1280))
+  }
+
+  @Test
   fun managesBrowserTabOrderAndActiveTab() {
     val tabs = BrowserTabs("https://one.example")
     tabs.add("https://two.example")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Desktop view now rewrites (or creates) the page viewport meta to Chromium’s default **980px** layout width, so responsive sites on phones actually get a desktop CSS viewport instead of only a desktop UA.
- Keeps wide-viewport + overview zoom so the desktop layout fits the physical screen; reapplies on page commit and page finish.

## Test plan
- [ ] On a phone-sized device/emulator, open a responsive site (e.g. one with `width=device-width`)
- [ ] Overflow menu → **Desktop view** → page should lay out at desktop width (zoomed to fit), not the phone breakpoint
- [ ] Overflow menu → **Phone view** → returns to normal mobile layout
- [ ] Navigate to another page while Desktop view stays on → desktop viewport still applied
- [x] `./gradlew testDebugUnitTest --tests com.searchlauncher.app.ui.browser.BrowserNavigationTest` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac29c06b-0201-4719-97a7-b1656eb0f4d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac29c06b-0201-4719-97a7-b1656eb0f4d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

