### PR TITLE
Allow favoriting more than just apps

### DIFF
--- a/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoriteKeys.kt
@@ -1,0 +1,69 @@
+package com.searchlauncher.app.data
+
+/**
+ * Favorites are stored as `"namespace/id"` keys so items from different indexes never collide.
+ *
+ * Legacy favorites were bare app package names; [normalize] rewrites those to `apps/<package>`.
+ */
+object FavoriteKeys {
+  private val KNOWN_NAMESPACES =
+    setOf(
+      "apps",
+      "shortcuts",
+      "static_shortcuts",
+      "search_shortcuts",
+      "app_shortcuts",
+      "contacts",
+      "snippets",
+      "web_bookmarks",
+      "web_saved",
+    )
+
+  fun of(namespace: String, id: String): String = "$namespace/$id"
+
+  fun of(result: SearchResult): String = of(result.namespace, result.id)
+
+  /** Returns namespace to id, or null if [key] is blank. */
+  fun parse(key: String): Pair<String, String>? {
+    val slash = key.indexOf('/')
+    if (slash <= 0 || slash >= key.length - 1) return null
+    return key.substring(0, slash) to key.substring(slash + 1)
+  }
+
+  /**
+   * Ensures [raw] is a namespaced favorite key. Bare ids (historical app favorites) become
+   * `apps/<id>`.
+   */
+  fun normalize(raw: String): String {
+    val slash = raw.indexOf('/')
+    if (slash > 0) {
+      val namespace = raw.substring(0, slash)
+      if (namespace in KNOWN_NAMESPACES && slash < raw.length - 1) {
+        return raw
+      }
+    }
+    return of("apps", raw)
+  }
+
+  /** Package name when [key] refers to an app favorite; otherwise null. */
+  fun appPackageName(key: String): String? {
+    val (namespace, id) = parse(normalize(key)) ?: return null
+    return id.takeIf { namespace == "apps" }
+  }
+}
+
+/** Stable key used for favorites storage, list identity, and reorder. */
+val SearchResult.favoriteKey: String
+  get() = FavoriteKeys.of(this)
+
+/** Whether this result can be pinned to the favorites row. */
+fun SearchResult.isFavoritable(): Boolean =
+  when (this) {
+    is SearchResult.App,
+    is SearchResult.Contact,
+    is SearchResult.Shortcut,
+    is SearchResult.Snippet,
+    is SearchResult.SearchIntent -> true
+    is SearchResult.Content -> namespace in setOf("app_shortcuts", "web_saved", "web_bookmarks")
+    is SearchResult.IndexingIndicator -> false
+  }

--- a/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/FavoritesRepository.kt
@@ -11,6 +11,7 @@ class FavoritesRepository(context: Context) {
     context.getSharedPreferences(Prefs.Favorites.FILE, Context.MODE_PRIVATE)
 
   private val _favoriteIds = MutableStateFlow<List<String>>(emptyList())
+  /** Ordered list of namespaced favorite keys (`namespace/id`). */
   val favoriteIds: StateFlow<List<String>> = _favoriteIds
 
   init {
@@ -25,9 +26,13 @@ class FavoritesRepository(context: Context) {
         val array = JSONArray(jsonString)
         val list = mutableListOf<String>()
         for (i in 0 until array.length()) {
-          list.add(array.getString(i))
+          list.add(FavoriteKeys.normalize(array.getString(i)))
         }
         _favoriteIds.value = list
+        // Persist migration from bare package ids → namespaced keys
+        if (list != (0 until array.length()).map { array.getString(it) }) {
+          saveFavorites(list)
+        }
         return
       } catch (e: Exception) {
         e.printStackTrace()
@@ -36,22 +41,33 @@ class FavoritesRepository(context: Context) {
 
     // Migration path: load from the old Set if JSON is missing
     val favoritesSet = prefs.getStringSet(Prefs.Favorites.IDS, emptySet()) ?: emptySet()
-    _favoriteIds.value = favoritesSet.toList()
+    val migrated = favoritesSet.map { FavoriteKeys.normalize(it) }
+    _favoriteIds.value = migrated
+    if (migrated.isNotEmpty()) {
+      saveFavorites(migrated)
+    }
   }
 
-  fun toggleFavorite(id: String) {
+  fun toggleFavorite(result: SearchResult) {
+    toggleFavorite(result.namespace, result.id)
+  }
+
+  fun toggleFavorite(namespace: String, id: String) {
+    val key = FavoriteKeys.of(namespace, id)
     val currentFavorites = _favoriteIds.value.toMutableList()
-    if (currentFavorites.contains(id)) {
-      currentFavorites.remove(id)
+    if (currentFavorites.contains(key)) {
+      currentFavorites.remove(key)
     } else {
-      currentFavorites.add(id)
+      currentFavorites.add(key)
     }
     _favoriteIds.value = currentFavorites
     saveFavorites(currentFavorites)
   }
 
-  fun isFavorite(id: String): Boolean {
-    return _favoriteIds.value.contains(id)
+  fun isFavorite(result: SearchResult): Boolean = isFavorite(result.namespace, result.id)
+
+  fun isFavorite(namespace: String, id: String): Boolean {
+    return _favoriteIds.value.contains(FavoriteKeys.of(namespace, id))
   }
 
   private fun saveFavorites(favorites: List<String>) {
@@ -63,8 +79,9 @@ class FavoritesRepository(context: Context) {
   }
 
   fun updateOrder(newOrder: List<String>) {
-    _favoriteIds.value = newOrder
-    saveFavorites(newOrder)
+    val normalized = newOrder.map { FavoriteKeys.normalize(it) }
+    _favoriteIds.value = normalized
+    saveFavorites(normalized)
   }
 
   fun getFavoriteIds(): List<String> {
@@ -72,8 +89,9 @@ class FavoritesRepository(context: Context) {
   }
 
   fun replaceAll(favorites: List<String>) {
-    _favoriteIds.value = favorites
-    saveFavorites(favorites)
+    val normalized = favorites.map { FavoriteKeys.normalize(it) }
+    _favoriteIds.value = normalized
+    saveFavorites(normalized)
   }
 
   fun clear() {

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -871,50 +871,45 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   suspend fun getResults(ids: List<String>, limit: Int = 100): List<SearchResult> =
     withContext(Dispatchers.IO) {
       if (ids.isEmpty()) return@withContext emptyList()
-      val targetIds = ids.take(limit)
+      // Accept both namespaced keys (`namespace/id`) and legacy bare app package ids.
+      val targetKeys = ids.take(limit).map { FavoriteKeys.normalize(it) }
+      val parsedKeys = targetKeys.mapNotNull { key -> FavoriteKeys.parse(key)?.let { key to it } }
 
-      // 1. Try Memory Cache
-      val snapshot = documentSnapshot
-      val cachedDocs = targetIds.mapNotNull { id -> snapshot.find { it.doc.id == id }?.doc }
+      // 1. Try Memory Cache (namespace + id)
+      val resolved = linkedMapOf<String, AppSearchDocument>()
+      for ((key, nsAndId) in parsedKeys) {
+        val (namespace, id) = nsAndId
+        documentByNamespaceAndId[documentLookupKey(namespace, id)]?.let { resolved[key] = it.doc }
+      }
 
-      // 2. Fetch missing from DB
-      val finalDocs =
-        if (cachedDocs.size < targetIds.size && appSearchSession != null) {
-          val missingIds = targetIds.filter { id -> cachedDocs.none { it.id == id } }
-          val resolved = mutableListOf<AppSearchDocument>()
-          val namespaces =
-            listOf(
-              "apps",
-              "shortcuts",
-              "static_shortcuts",
-              "search_shortcuts",
-              "app_shortcuts",
-              "contacts",
-              "snippets",
-              "web_bookmarks", // Include web bookmarks for favorites/history
-              "web_saved",
-            )
-          for (ns in namespaces) {
-            try {
-              val req =
-                androidx.appsearch.app.GetByDocumentIdRequest.Builder(ns).addIds(missingIds).build()
-              val resp = appSearchSession?.getByDocumentIdAsync(req)?.await()
-              resp?.successes?.values?.forEach { gDoc ->
-                val doc = gDoc.toDocumentClass(AppSearchDocument::class.java)
-                resolved.add(doc)
+      // 2. Fetch missing from DB, scoped to each key's namespace
+      val missing = parsedKeys.filter { (key, _) -> key !in resolved }
+      if (missing.isNotEmpty() && appSearchSession != null) {
+        val byNamespace = missing.groupBy({ it.second.first }, { it.first to it.second.second })
+        for ((namespace, entries) in byNamespace) {
+          try {
+            val req =
+              androidx.appsearch.app.GetByDocumentIdRequest.Builder(namespace)
+                .addIds(entries.map { it.second })
+                .build()
+            val resp = appSearchSession?.getByDocumentIdAsync(req)?.await()
+            resp?.successes?.forEach { (id, gDoc) ->
+              val doc = gDoc.toDocumentClass(AppSearchDocument::class.java)
+              val key = FavoriteKeys.of(namespace, id)
+              if (key in targetKeys) {
+                resolved[key] = doc
               }
-              if (resolved.size >= missingIds.size) break
-            } catch (e: Exception) {
-              // Ignore failures for specific namespaces
-              Sentry.captureException(e)
             }
+          } catch (e: Exception) {
+            // Ignore failures for specific namespaces
+            Sentry.captureException(e)
           }
-          targetIds.mapNotNull { id ->
-            cachedDocs.find { it.id == id } ?: resolved.find { it.id == id }
-          }
-        } else cachedDocs
+        }
+      }
 
-      finalDocs.map { convertDocumentToResult(wrap(it), 100, saveToDisk = true) }
+      targetKeys.mapNotNull { key ->
+        resolved[key]?.let { convertDocumentToResult(wrap(it), 100, saveToDisk = true) }
+      }
     }
 
   suspend fun getRecentItems(

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchActivity.kt
@@ -32,7 +32,7 @@ class SearchActivity : ComponentActivity() {
 
     setContent {
       val context = LocalContext.current
-      val query = remember { mutableStateOf("") }
+      val query = remember { mutableStateOf(intent.getStringExtra(EXTRA_INITIAL_QUERY).orEmpty()) }
       val browserSearchMode = intent.getBooleanExtra(EXTRA_BROWSER_SEARCH, false)
       val chromeBarColor =
         intent
@@ -79,5 +79,6 @@ class SearchActivity : ComponentActivity() {
     const val EXTRA_START_VOICE_SEARCH = "start_voice_search"
     const val EXTRA_BROWSER_SEARCH = "browser_search"
     const val EXTRA_CHROME_COLOR = "chrome_color"
+    const val EXTRA_INITIAL_QUERY = "initial_query"
   }
 }

--- a/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/SearchScreen.kt
@@ -56,6 +56,8 @@ import androidx.datastore.preferences.core.edit
 import com.searchlauncher.app.data.Prefs
 import com.searchlauncher.app.data.SearchRepository
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.favoriteKey
+import com.searchlauncher.app.data.isFavoritable
 import com.searchlauncher.app.ui.browser.BrowserActivity
 import com.searchlauncher.app.ui.components.BookmarkDialog
 import com.searchlauncher.app.ui.components.ConsentDialog
@@ -155,7 +157,8 @@ fun SearchScreen(
     remember(rawHistoryItems, favoriteIds, historyLimit) {
       if (historyLimit == 0) emptyList()
       else {
-        val filtered = rawHistoryItems.filter { !favoriteIds.contains(it.id) }
+        val favoriteKeys = favoriteIds.toSet()
+        val filtered = rawHistoryItems.filter { it.favoriteKey !in favoriteKeys }
         if (historyLimit >= 0) filtered.take(historyLimit) else filtered
       }
     }
@@ -866,11 +869,11 @@ fun SearchScreen(
                     val webUrl = webUrlForResult(result, query, searchShortcuts)
                     SearchResultItem(
                       result = result,
-                      isFavorite = favoriteIds.contains(result.id),
+                      isFavorite = app.favoritesRepository.isFavorite(result),
                       onToggleFavorite =
-                        if (result is SearchResult.App) {
+                        if (result.isFavoritable()) {
                           {
-                            app.favoritesRepository.toggleFavorite(result.id)
+                            app.favoritesRepository.toggleFavorite(result)
                             onQueryChange("")
                             scope.launch {
                               onboardingManager.markStepComplete(OnboardingStep.AddFavorite)
@@ -1136,10 +1139,15 @@ fun SearchScreen(
             historyLimit = historyLimit,
             minIconSizeSetting = minIconSizeSetting,
             onLaunch = { result ->
-              resultLauncher.launch(result, reportUsage = true)
-              onDismiss()
+              if (result is SearchResult.SearchIntent) {
+                searchRepository.reportUsageAsync(result.namespace, result.id)
+                onQueryChange(result.trigger + " ")
+              } else {
+                resultLauncher.launch(result, reportUsage = true)
+                onDismiss()
+              }
             },
-            onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result.id) },
+            onToggleFavorite = { result -> app.favoritesRepository.toggleFavorite(result) },
             onReorder = { newOrder ->
               app.favoritesRepository.updateOrder(newOrder)
               scope.launch { onboardingManager.markStepComplete(OnboardingStep.ReorderFavorites) }

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -229,12 +229,13 @@ private fun BrowserScreen(
 ) {
   val context = LocalContext.current
   val app = context.applicationContext as SearchLauncherApp
-  // Read the shared favorites/history flows so the browser strip matches search.
-  // Writes (toggle/reorder/usage) stay gated on !privateMode below.
-  val searchRepository = app.searchRepository
+  // Always read the shared favorites flow so the browser strip matches search.
+  // Keep searchRepository null in private mode so browsing never writes index/history/favicons.
+  val sharedSearchRepository = app.searchRepository
+  val searchRepository = if (privateMode) null else sharedSearchRepository
   val favoriteIds by app.favoritesRepository.favoriteIds.collectAsState()
-  val favorites by searchRepository.favorites.collectAsState()
-  val allRecentItems by searchRepository.recentItems.collectAsState()
+  val favorites by sharedSearchRepository.favorites.collectAsState()
+  val allRecentItems by sharedSearchRepository.recentItems.collectAsState()
   val historyLimit by
     remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
       .collectAsState(initial = -1)
@@ -266,8 +267,12 @@ private fun BrowserScreen(
       .collectAsState(initial = true)
   val coroutineScope = rememberCoroutineScope()
   val resultLauncher =
-    remember(context, searchRepository, coroutineScope) {
-      ResultLauncher(context = context, searchRepository = searchRepository, scope = coroutineScope)
+    remember(context, sharedSearchRepository, coroutineScope) {
+      ResultLauncher(
+        context = context,
+        searchRepository = sharedSearchRepository,
+        scope = coroutineScope,
+      )
     }
   val initialNavigationRequest = remember { navigationRequest }
   val defaultPageBackground = MaterialTheme.colorScheme.background
@@ -925,9 +930,7 @@ private fun BrowserScreen(
             }
           },
           onHistoryCapacityChanged = { limit ->
-            if (!privateMode) {
-              searchRepository.updateObservedHistoryLimit(limit)
-            }
+            searchRepository?.updateObservedHistoryLimit(limit)
           },
           onHide = { chromeHiddenByUser = true },
           modifier =

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -86,12 +86,11 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.searchlauncher.app.SearchLauncherApp
-import com.searchlauncher.app.data.FavoriteKeys
-import com.searchlauncher.app.data.FavoritesRepository
 import com.searchlauncher.app.data.SearchResult
 import com.searchlauncher.app.data.favoriteKey
 import com.searchlauncher.app.ui.MinIconSize
 import com.searchlauncher.app.ui.PreferencesKeys
+import com.searchlauncher.app.ui.ResultLauncher
 import com.searchlauncher.app.ui.SearchActivity
 import com.searchlauncher.app.ui.components.BookmarkDialog
 import com.searchlauncher.app.ui.components.FavoritesRow
@@ -100,12 +99,9 @@ import com.searchlauncher.app.ui.dataStore
 import com.searchlauncher.app.ui.theme.SearchLauncherTheme
 import kotlin.math.abs
 import kotlin.math.roundToInt
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 open class BrowserActivity : ComponentActivity() {
   private var navigationRequest by mutableStateOf<NavigationRequest?>(null)
@@ -137,7 +133,7 @@ open class BrowserActivity : ComponentActivity() {
           showLauncherChrome = !searchOverlayVisible,
           browserMenuRequest = browserMenuRequest,
           onBrowserMenuShown = { browserMenuRequest = 0L },
-          onOpenSearch = ::openSearch,
+          onOpenSearch = { voice, color, query -> openSearch(voice, color, query) },
           onClose = ::finish,
         )
       }
@@ -164,7 +160,11 @@ open class BrowserActivity : ComponentActivity() {
   private fun <T> preference(key: Preferences.Key<T>, default: T): State<T> =
     remember(key) { dataStore.data.map { it[key] ?: default } }.collectAsState(initial = default)
 
-  private fun openSearch(startVoiceSearch: Boolean, chromeColorArgb: Int) {
+  private fun openSearch(
+    startVoiceSearch: Boolean,
+    chromeColorArgb: Int,
+    initialQuery: String = "",
+  ) {
     searchOverlayVisible = true
     startActivity(
       Intent(this, SearchActivity::class.java)
@@ -172,6 +172,7 @@ open class BrowserActivity : ComponentActivity() {
         .putExtra(SearchActivity.EXTRA_START_VOICE_SEARCH, startVoiceSearch)
         .putExtra(SearchActivity.EXTRA_BROWSER_SEARCH, true)
         .putExtra(SearchActivity.EXTRA_CHROME_COLOR, chromeColorArgb)
+        .putExtra(SearchActivity.EXTRA_INITIAL_QUERY, initialQuery)
     )
   }
 
@@ -223,33 +224,29 @@ private fun BrowserScreen(
   showLauncherChrome: Boolean,
   browserMenuRequest: Long,
   onBrowserMenuShown: () -> Unit,
-  onOpenSearch: (Boolean, Int) -> Unit,
+  onOpenSearch: (Boolean, Int, String) -> Unit,
   onClose: () -> Unit,
 ) {
   val context = LocalContext.current
-  val searchRepository =
-    if (privateMode) null else (context.applicationContext as SearchLauncherApp).searchRepository
-  val favoritesRepository = rememberFavoritesRepository(privateMode)
-  val favoriteIds by favoritesRepository.collectAsState()
-  val favoriteApps by favoriteApps(favoriteIds)
-  val rawHistoryItems =
-    if (searchRepository != null) searchRepository.recentItems.collectAsState().value
-    else emptyList()
+  val app = context.applicationContext as SearchLauncherApp
+  // Read the shared favorites/history flows so the browser strip matches search.
+  // Writes (toggle/reorder/usage) stay gated on !privateMode below.
+  val searchRepository = app.searchRepository
+  val favoriteIds by app.favoritesRepository.favoriteIds.collectAsState()
+  val favorites by searchRepository.favorites.collectAsState()
+  val allRecentItems by searchRepository.recentItems.collectAsState()
   val historyLimit by
     remember { context.dataStore.data.map { it[PreferencesKeys.HISTORY_LIMIT] ?: -1 } }
       .collectAsState(initial = -1)
   val minIconSizeSetting by
     remember { MinIconSize.flow(context) }.collectAsState(initial = MinIconSize.cached(context))
-  val recentApps =
-    remember(rawHistoryItems, favoriteIds, historyLimit) {
-      if (historyLimit == 0) emptyList()
+  val historyItems =
+    remember(allRecentItems, favoriteIds, historyLimit, privateMode) {
+      if (privateMode || historyLimit == 0) emptyList()
       else {
         val favoriteKeys = favoriteIds.toSet()
-        val apps =
-          rawHistoryItems.filterIsInstance<SearchResult.App>().filterNot {
-            it.favoriteKey in favoriteKeys
-          }
-        if (historyLimit >= 0) apps.take(historyLimit) else apps
+        val filtered = allRecentItems.filter { it.favoriteKey !in favoriteKeys }
+        if (historyLimit >= 0) filtered.take(historyLimit) else filtered
       }
     }
   // Hidden by default while browsing: the page is the focus, and the row is a lot of UI.
@@ -268,6 +265,10 @@ private fun BrowserScreen(
       }
       .collectAsState(initial = true)
   val coroutineScope = rememberCoroutineScope()
+  val resultLauncher =
+    remember(context, searchRepository, coroutineScope) {
+      ResultLauncher(context = context, searchRepository = searchRepository, scope = coroutineScope)
+    }
   val initialNavigationRequest = remember { navigationRequest }
   val defaultPageBackground = MaterialTheme.colorScheme.background
   val tabs = remember {
@@ -384,7 +385,7 @@ private fun BrowserScreen(
           tabDragOffsetPx = value
         }
         tabsInMotion = false
-        onOpenSearch(false, defaultPageBackground.toArgb())
+        onOpenSearch(false, defaultPageBackground.toArgb(), "")
       }
   }
 
@@ -893,39 +894,40 @@ private fun BrowserScreen(
         exit = slideOutVertically { it } + fadeOut(),
       ) {
         BrowserLauncherChrome(
-          favoriteApps = favoriteApps,
-          recentApps = recentApps,
+          favorites = favorites,
+          historyItems = historyItems,
           historyLimit = historyLimit,
           minIconSizeSetting = minIconSizeSetting,
           showFavorites = showFavorites,
           barColor = chromeBarColor,
           barContentColor = chromeBarContentColor,
           overflowMenu = browserOverflowMenu,
-          onOpenSearch = { onOpenSearch(false, pageBackground.toArgb()) },
-          onVoiceSearch = { onOpenSearch(true, pageBackground.toArgb()) },
+          onOpenSearch = { onOpenSearch(false, pageBackground.toArgb(), "") },
+          onVoiceSearch = { onOpenSearch(true, pageBackground.toArgb(), "") },
           onTabDragStart = tabDragStart,
           onTabDrag = tabDrag,
           onTabDragEnd = tabDragEnd,
           onLaunchFavorite = { result ->
-            context.packageManager.getLaunchIntentForPackage(result.packageName)?.let { intent ->
-              intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-              context.startActivity(intent)
+            if (result is SearchResult.SearchIntent) {
+              onOpenSearch(false, pageBackground.toArgb(), result.trigger + " ")
+            } else {
+              resultLauncher.launch(result, reportUsage = !privateMode)
             }
           },
           onToggleFavorite = { result ->
             if (!privateMode) {
-              (context.applicationContext as SearchLauncherApp)
-                .favoritesRepository
-                .toggleFavorite(result)
+              app.favoritesRepository.toggleFavorite(result)
             }
           },
           onReorder = { ids ->
             if (!privateMode) {
-              (context.applicationContext as SearchLauncherApp).favoritesRepository.updateOrder(ids)
+              app.favoritesRepository.updateOrder(ids)
             }
           },
           onHistoryCapacityChanged = { limit ->
-            searchRepository?.updateObservedHistoryLimit(limit)
+            if (!privateMode) {
+              searchRepository.updateObservedHistoryLimit(limit)
+            }
           },
           onHide = { chromeHiddenByUser = true },
           modifier =
@@ -969,8 +971,8 @@ private fun BrowserScreen(
           barColor = chromeBarColor,
           barContentColor = chromeBarContentColor,
           onReveal = { chromeHiddenByUser = false },
-          onSearch = { onOpenSearch(false, pageBackground.toArgb()) },
-          onVoiceSearch = { onOpenSearch(true, pageBackground.toArgb()) },
+          onSearch = { onOpenSearch(false, pageBackground.toArgb(), "") },
+          onVoiceSearch = { onOpenSearch(true, pageBackground.toArgb(), "") },
           onTabDragStart = tabDragStart,
           onTabDrag = tabDrag,
           onTabDragEnd = tabDragEnd,
@@ -1102,44 +1104,9 @@ private fun BrowserScreen(
 }
 
 @Composable
-private fun rememberFavoritesRepository(privateMode: Boolean): StateFlow<List<String>> {
-  val context = LocalContext.current
-  return remember(privateMode) {
-    if (privateMode) FavoritesRepository(context).favoriteIds
-    else (context.applicationContext as SearchLauncherApp).favoritesRepository.favoriteIds
-  }
-}
-
-@Composable
-private fun favoriteApps(favoriteIds: List<String>): State<List<SearchResult.App>> {
-  val context = LocalContext.current
-  return produceState(emptyList(), favoriteIds) {
-    value =
-      withContext(Dispatchers.IO) {
-        // Browser chrome only shows app favorites (PackageManager resolution).
-        favoriteIds.mapNotNull { key ->
-          val packageName = FavoriteKeys.appPackageName(key) ?: return@mapNotNull null
-          val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
-          if (launchIntent == null) return@mapNotNull null
-          val appInfo =
-            runCatching { context.packageManager.getApplicationInfo(packageName, 0) }.getOrNull()
-              ?: return@mapNotNull null
-          SearchResult.App(
-            id = packageName,
-            title = context.packageManager.getApplicationLabel(appInfo).toString(),
-            subtitle = null,
-            icon = context.packageManager.getApplicationIcon(appInfo),
-            packageName = packageName,
-          )
-        }
-      }
-  }
-}
-
-@Composable
 private fun BrowserLauncherChrome(
-  favoriteApps: List<SearchResult.App>,
-  recentApps: List<SearchResult.App>,
+  favorites: List<SearchResult>,
+  historyItems: List<SearchResult>,
   historyLimit: Int,
   minIconSizeSetting: Int,
   showFavorites: Boolean,
@@ -1151,8 +1118,8 @@ private fun BrowserLauncherChrome(
   onTabDragStart: () -> Unit,
   onTabDrag: (Float) -> Unit,
   onTabDragEnd: () -> Unit,
-  onLaunchFavorite: (SearchResult.App) -> Unit,
-  onToggleFavorite: (SearchResult.App) -> Unit,
+  onLaunchFavorite: (SearchResult) -> Unit,
+  onToggleFavorite: (SearchResult) -> Unit,
   onReorder: (List<String>) -> Unit,
   onHistoryCapacityChanged: (Int) -> Unit,
   onHide: () -> Unit,
@@ -1201,18 +1168,18 @@ private fun BrowserLauncherChrome(
         .padding(top = 8.dp, bottom = 4.dp)
   ) {
     AnimatedVisibility(
-      visible = showFavorites && (favoriteApps.isNotEmpty() || recentApps.isNotEmpty()),
+      visible = showFavorites && (favorites.isNotEmpty() || historyItems.isNotEmpty()),
       enter = expandVertically() + fadeIn(),
       exit = shrinkVertically() + fadeOut(),
     ) {
       Column {
         FavoritesRow(
-          favorites = favoriteApps,
-          history = recentApps,
+          favorites = favorites,
+          history = historyItems,
           historyLimit = historyLimit,
           minIconSizeSetting = minIconSizeSetting,
-          onLaunch = { onLaunchFavorite(it as SearchResult.App) },
-          onToggleFavorite = { onToggleFavorite(it as SearchResult.App) },
+          onLaunch = onLaunchFavorite,
+          onToggleFavorite = onToggleFavorite,
           onReorder = onReorder,
           onCapacityChanged = onHistoryCapacityChanged,
         )

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -86,8 +86,10 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.searchlauncher.app.SearchLauncherApp
+import com.searchlauncher.app.data.FavoriteKeys
 import com.searchlauncher.app.data.FavoritesRepository
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.favoriteKey
 import com.searchlauncher.app.ui.MinIconSize
 import com.searchlauncher.app.ui.PreferencesKeys
 import com.searchlauncher.app.ui.SearchActivity
@@ -242,8 +244,11 @@ private fun BrowserScreen(
     remember(rawHistoryItems, favoriteIds, historyLimit) {
       if (historyLimit == 0) emptyList()
       else {
+        val favoriteKeys = favoriteIds.toSet()
         val apps =
-          rawHistoryItems.filterIsInstance<SearchResult.App>().filterNot { it.id in favoriteIds }
+          rawHistoryItems.filterIsInstance<SearchResult.App>().filterNot {
+            it.favoriteKey in favoriteKeys
+          }
         if (historyLimit >= 0) apps.take(historyLimit) else apps
       }
     }
@@ -911,7 +916,7 @@ private fun BrowserScreen(
             if (!privateMode) {
               (context.applicationContext as SearchLauncherApp)
                 .favoritesRepository
-                .toggleFavorite(result.id)
+                .toggleFavorite(result)
             }
           },
           onReorder = { ids ->
@@ -1111,7 +1116,9 @@ private fun favoriteApps(favoriteIds: List<String>): State<List<SearchResult.App
   return produceState(emptyList(), favoriteIds) {
     value =
       withContext(Dispatchers.IO) {
-        favoriteIds.mapNotNull { packageName ->
+        // Browser chrome only shows app favorites (PackageManager resolution).
+        favoriteIds.mapNotNull { key ->
+          val packageName = FavoriteKeys.appPackageName(key) ?: return@mapNotNull null
           val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
           if (launchIntent == null) return@mapNotNull null
           val appInfo =

--- a/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/components/FavoritesRow.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.searchlauncher.app.data.SearchResult
+import com.searchlauncher.app.data.favoriteKey
 import com.searchlauncher.app.ui.toImageBitmap
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -89,7 +90,7 @@ fun FavoritesRow(
     var draggedItemId by remember { mutableStateOf<String?>(null) }
     var dragPosition by remember { mutableStateOf(Offset.Zero) }
     var totalDragX by remember { mutableStateOf(0f) }
-    var currentOrder by remember(allItems) { mutableStateOf(allItems.map { it.id }) }
+    var currentOrder by remember(allItems) { mutableStateOf(allItems.map { it.favoriteKey }) }
     var showMenuForIndex by remember { mutableStateOf<Int?>(null) }
     var dragBoundaryIndex by remember(boundaryIndex) { mutableStateOf(boundaryIndex) }
     var initialDragIndex by remember { mutableStateOf(-1) }
@@ -101,7 +102,8 @@ fun FavoritesRow(
       val id = draggedItemId ?: return@LaunchedEffect
       val bestIdx = currentOrder.indexOf(id).coerceAtLeast(0)
       val wasFavorite =
-        boundaryIndex > allItems.indexOfFirst { it.id == id }.let { if (it == -1) 0 else it }
+        boundaryIndex >
+          allItems.indexOfFirst { it.favoriteKey == id }.let { if (it == -1) 0 else it }
 
       dragBoundaryIndex =
         if (wasFavorite) {
@@ -114,7 +116,7 @@ fun FavoritesRow(
 
     // Caching icons to prevent flickering
     val iconBitmaps =
-      remember(allItems) { allItems.associate { it.id to it.icon?.toImageBitmap() } }
+      remember(allItems) { allItems.associate { it.favoriteKey to it.icon?.toImageBitmap() } }
 
     // Calculate layout metrics
     // We reserve space for the divider gap if needed
@@ -171,11 +173,11 @@ fun FavoritesRow(
       }
 
       allItems.forEach { result ->
-        key(result.id) {
-          val id = result.id
+        val itemKey = result.favoriteKey
+        key(itemKey) {
           val currentIndex =
-            currentOrder.indexOf(id).takeIf { it != -1 } ?: allItems.indexOf(result)
-          val isGhost = id == draggedItemId
+            currentOrder.indexOf(itemKey).takeIf { it != -1 } ?: allItems.indexOf(result)
+          val isGhost = itemKey == draggedItemId
 
           // Use static position for the Box receiving gestures to avoid fighting the animation
           val displayIndex = if (isGhost) initialDragIndex else currentIndex
@@ -193,17 +195,17 @@ fun FavoritesRow(
                 .size(finalIconSize)
                 .clip(RoundedCornerShape(12.dp))
                 .graphicsLayer { alpha = if (isGhost) 0f else 1f }
-                .pointerInput(result.id) { detectTapGestures(onTap = { onLaunch(result) }) }
-                .pointerInput(result.id, startX, itemWidthPx) {
+                .pointerInput(itemKey) { detectTapGestures(onTap = { onLaunch(result) }) }
+                .pointerInput(itemKey, startX, itemWidthPx) {
                   detectDragGesturesAfterLongPress(
                     onDragStart = { offset ->
-                      val freshIndex = currentOrder.indexOf(id).takeIf { it != -1 } ?: 0
+                      val freshIndex = currentOrder.indexOf(itemKey).takeIf { it != -1 } ?: 0
                       initialDragIndex = freshIndex
 
                       // Calculate CURRENT visual position for smooth handoff
                       val currentVisualXPx = startX + with(density) { animatedRelativeXDp.toPx() }
 
-                      draggedItemId = id
+                      draggedItemId = itemKey
                       dragPosition = Offset(currentVisualXPx + offset.x, offset.y)
                       totalDragX = 0f
                       haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -246,7 +248,7 @@ fun FavoritesRow(
                         showMenuForIndex = finalIdx
                       } else {
                         // REORDER / MOVE Logic
-                        val wasFavorite = favorites.any { it.id == draggedId }
+                        val wasFavorite = favorites.any { it.favoriteKey == draggedId }
                         val isNowInFavoriteZone = finalIdx < boundaryIndex
 
                         if (!wasFavorite && isNowInFavoriteZone) {
@@ -275,7 +277,7 @@ fun FavoritesRow(
                 },
             contentAlignment = Alignment.Center,
           ) {
-            val imageBitmap = iconBitmaps[id]
+            val imageBitmap = iconBitmaps[itemKey]
             if (imageBitmap != null) {
               Image(
                 bitmap = imageBitmap,
@@ -309,7 +311,7 @@ fun FavoritesRow(
               modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant),
               properties = PopupProperties(focusable = false),
             ) {
-              val isFavorite = favorites.any { it.id == result.id }
+              val isFavorite = favorites.any { it.favoriteKey == result.favoriteKey }
 
               AppActionsMenuItems(
                 result = result,
@@ -327,7 +329,7 @@ fun FavoritesRow(
     // 2. Drag Overlay
     // Positioned using global coordinates derived from gesture
     draggedItemId?.let { id ->
-      val result = allItems.find { it.id == id } ?: return@let
+      val result = allItems.find { it.favoriteKey == id } ?: return@let
       val imageBitmap = iconBitmaps[id] ?: return@let
 
       Box(modifier = Modifier.fillMaxWidth().height(finalIconSize)) {

--- a/app/src/main/java/com/searchlauncher/app/ui/onboarding/TutorialOverlay.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/onboarding/TutorialOverlay.kt
@@ -119,13 +119,13 @@ fun TutorialOverlay(
           // overlay
           // For now, let's put a subtle indicator near the top where results appear
           TextHintIndicator(
-            text = "Long press an app to Favorite",
+            text = "Long press a result to Favorite",
             modifier = Modifier.align(Alignment.Center).padding(bottom = 100.dp),
           )
         }
         OnboardingStep.ReorderFavorites -> {
           TextHintIndicator(
-            text = "Hold app icons to change order",
+            text = "Hold favorite icons to change order",
             modifier = Modifier.align(Alignment.Center).padding(bottom = 150.dp),
           )
         }

--- a/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoriteKeysTest.kt
@@ -1,0 +1,126 @@
+package com.searchlauncher.app.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FavoriteKeysTest {
+  @Test
+  fun `of joins namespace and id`() {
+    assertEquals("apps/com.example", FavoriteKeys.of("apps", "com.example"))
+    assertEquals(
+      "shortcuts/com.example/shortcut1",
+      FavoriteKeys.of("shortcuts", "com.example/shortcut1"),
+    )
+  }
+
+  @Test
+  fun `parse splits on first slash`() {
+    assertEquals("apps" to "com.example", FavoriteKeys.parse("apps/com.example"))
+    assertEquals("contacts" to "lookup/42", FavoriteKeys.parse("contacts/lookup/42"))
+    assertNull(FavoriteKeys.parse("noslash"))
+    assertNull(FavoriteKeys.parse("/leading"))
+    assertNull(FavoriteKeys.parse("trailing/"))
+  }
+
+  @Test
+  fun `normalize migrates bare package names to apps`() {
+    assertEquals("apps/com.whatsapp", FavoriteKeys.normalize("com.whatsapp"))
+    assertEquals("apps/com.whatsapp", FavoriteKeys.normalize("apps/com.whatsapp"))
+    assertEquals("snippets/hello", FavoriteKeys.normalize("snippets/hello"))
+  }
+
+  @Test
+  fun `appPackageName only returns apps`() {
+    assertEquals("com.whatsapp", FavoriteKeys.appPackageName("apps/com.whatsapp"))
+    assertEquals("com.whatsapp", FavoriteKeys.appPackageName("com.whatsapp"))
+    assertNull(FavoriteKeys.appPackageName("contacts/lookup/1"))
+    assertNull(FavoriteKeys.appPackageName("snippets/alias"))
+  }
+
+  @Test
+  fun `isFavoritable covers durable result types`() {
+    assertTrue(
+      SearchResult.App(
+          id = "com.example",
+          title = "Example",
+          subtitle = null,
+          icon = null,
+          packageName = "com.example",
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.Contact(
+          id = "lk/1",
+          title = "Ada",
+          subtitle = null,
+          icon = null,
+          lookupKey = "lk",
+          contactId = 1L,
+          photoUri = null,
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.Shortcut(
+          id = "com.example/s1",
+          title = "Shortcut",
+          subtitle = null,
+          icon = null,
+          packageName = "com.example",
+          intentUri = "shortcut://com.example/s1",
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.Snippet(
+          id = "hi",
+          title = "Hi",
+          subtitle = null,
+          icon = null,
+          alias = "hi",
+          content = "hello",
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.SearchIntent(
+          id = "search_google",
+          namespace = "search_shortcuts",
+          title = "Google",
+          subtitle = null,
+          icon = null,
+          trigger = "g",
+        )
+        .isFavoritable()
+    )
+    assertTrue(
+      SearchResult.Content(
+          id = "saved_1",
+          namespace = "web_saved",
+          title = "Saved",
+          subtitle = null,
+          icon = null,
+          packageName = "",
+          deepLink = "https://example.com",
+        )
+        .isFavoritable()
+    )
+    assertFalse(
+      SearchResult.Content(
+          id = "calc",
+          namespace = "calculator",
+          title = "1+1",
+          subtitle = null,
+          icon = null,
+          packageName = "",
+          deepLink = "calculator://copy?text=2",
+        )
+        .isFavoritable()
+    )
+    assertFalse(SearchResult.IndexingIndicator().isFavoritable())
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/FavoritesRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/FavoritesRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.searchlauncher.app.SearchLauncherApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = SearchLauncherApp::class)
+class FavoritesRepositoryTest {
+  private lateinit var context: Context
+
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+    context.getSharedPreferences(Prefs.Favorites.FILE, Context.MODE_PRIVATE).edit().clear().commit()
+  }
+
+  @Test
+  fun `toggleFavorite stores namespaced keys`() {
+    val repo = FavoritesRepository(context)
+    val contact =
+      SearchResult.Contact(
+        id = "lk/1",
+        title = "Ada",
+        subtitle = null,
+        icon = null,
+        lookupKey = "lk",
+        contactId = 1L,
+        photoUri = null,
+      )
+
+    repo.toggleFavorite(contact)
+    assertEquals(listOf("contacts/lk/1"), repo.getFavoriteIds())
+    assertTrue(repo.isFavorite(contact))
+
+    repo.toggleFavorite(contact)
+    assertTrue(repo.getFavoriteIds().isEmpty())
+    assertFalse(repo.isFavorite(contact))
+  }
+
+  @Test
+  fun `loads and migrates legacy bare package favorites`() {
+    val prefs = context.getSharedPreferences(Prefs.Favorites.FILE, Context.MODE_PRIVATE)
+    prefs
+      .edit()
+      .putString(Prefs.Favorites.IDS_ORDERED, """["com.whatsapp","com.android.settings"]""")
+      .commit()
+
+    val repo = FavoritesRepository(context)
+    assertEquals(listOf("apps/com.whatsapp", "apps/com.android.settings"), repo.getFavoriteIds())
+
+    // Migration is persisted
+    val reloaded = FavoritesRepository(context)
+    assertEquals(
+      listOf("apps/com.whatsapp", "apps/com.android.settings"),
+      reloaded.getFavoriteIds(),
+    )
+  }
+
+  @Test
+  fun `replaceAll normalizes mixed legacy and namespaced keys`() {
+    val repo = FavoritesRepository(context)
+    repo.replaceAll(listOf("com.example", "snippets/hello", "contacts/lk/2"))
+    assertEquals(
+      listOf("apps/com.example", "snippets/hello", "contacts/lk/2"),
+      repo.getFavoriteIds(),
+    )
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -166,6 +166,60 @@ class SearchRepositoryTest {
   }
 
   @Test
+  fun `getResults resolves namespaced favorite keys in order`() = runBlocking {
+    // Same bare id in two namespaces — resolution must use the namespace from the key.
+    val app =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "shared",
+        score = 1,
+        name = "Shared App",
+        intentUri = "intent://shared",
+        isAction = false,
+        iconResId = 0L,
+      )
+    val snippet =
+      AppSearchDocument(
+        namespace = "snippets",
+        id = "shared",
+        score = 1,
+        name = "Shared Snippet",
+        description = "hello",
+        isAction = false,
+        iconResId = 0L,
+      )
+    val otherApp =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.test.other",
+        score = 1,
+        name = "Other",
+        intentUri = "intent://other",
+        isAction = false,
+        iconResId = 0L,
+      )
+
+    repository.documentSnapshot =
+      listOf(repository.wrap(app), repository.wrap(snippet), repository.wrap(otherApp)).sortedBy {
+        it.namespaceInt
+      }
+
+    val results =
+      repository.getResults(
+        listOf(
+          "snippets/shared",
+          "com.test.other", // legacy bare app id
+          "apps/shared",
+        )
+      )
+
+    assertEquals(listOf("shared", "com.test.other", "shared"), results.map { it.id })
+    assertEquals(listOf("snippets", "apps", "apps"), results.map { it.namespace })
+    assertTrue(results[0] is SearchResult.Snippet)
+    assertTrue(results[2] is SearchResult.App)
+  }
+
+  @Test
   fun `markIndexingStarted stays silent when a live snapshot already exists`() {
     val app =
       AppSearchDocument(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Favorites were limited to apps in the search UI even though storage and the favorites row already work with generic `SearchResult`s.

### Changes
- Store favorites as namespaced keys (`namespace/id`) and migrate legacy bare package ids to `apps/<package>`
- Resolve favorites/history lookups by namespace + id (avoids cross-namespace id collisions)
- Allow favoriting durable result types: apps, contacts, shortcuts, snippets, search shortcuts, saved/history bookmarks, and app actions
- Browser chrome favorites strip now uses the same shared favorites list and launch path as search
- Private browsing still does not write index/history/favicons
- Update onboarding copy; add unit tests for keys, migration, and namespaced resolution

### Test plan
- [x] Unit tests: `FavoriteKeysTest`, `FavoritesRepositoryTest`, namespaced `getResults`
- [ ] Long-press a contact/shortcut/snippet/bookmark in search → Add Favorite → appears in favorites row
- [ ] Same favorites appear in browser chrome when favorites are enabled
- [ ] Tap favorited non-app results from search and browser (contact opens, snippet copies, search shortcut fills query)
- [ ] Existing app favorites still load after upgrade (migration)
- [ ] Reorder mixed favorites; remove via long-press menu
- [ ] Private browsing does not record visited pages into search history
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e3e7e14-1869-4cfc-8a32-bba141ebb489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e3e7e14-1869-4cfc-8a32-bba141ebb489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

