### PR TITLE
Drop explicit Raycast mention from the website

### DIFF
--- a/website/COPY.md
+++ b/website/COPY.md
@@ -86,7 +86,7 @@ SearchLauncher · Features · Privacy · Download
 - **Alt micro-line (optional under CTA):** Use it as your launcher, or as a widget on any home screen.
 
 ### Proof strip
-> Finally, a launcher for people who type faster than they swipe. It’s the power of Raycast, now in your pocket.
+> Finally, a launcher for people who type faster than they swipe. A command palette for your pocket.
 
 ### Section 1 — Search everything
 **Eyebrow / kicker:** Search

--- a/website/index.html
+++ b/website/index.html
@@ -659,7 +659,7 @@
     <section class="quote-band" aria-label="Positioning">
       <div class="wrap">
         <blockquote class="quote reveal">
-          Finally, a launcher for people who type faster than they swipe. It’s the power of Raycast, now in your pocket.
+          Finally, a launcher for people who type faster than they swipe. A command palette for your pocket.
         </blockquote>
       </div>
     </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Removes the explicit Raycast name from the public marketing quote.

**Before:** “It’s the power of Raycast, now in your pocket.”  
**After:** “A command palette for your pocket.”

Naming another product can be fine as nominative fair use in some cases, but it’s unnecessary risk for a marketing line. Category language (“command palette”) is clearer for people who don’t know Raycast anyway.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-119ad200-590e-4230-8e2c-d4f28d8dce2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-119ad200-590e-4230-8e2c-d4f28d8dce2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

