### PR TITLE
Keep indexing off the interactive path

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 253
-    versionName = "0.0.15"
+    versionCode = 254
+    versionName = "0.0.16"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/AppIndexer.kt
@@ -16,8 +16,16 @@ class AppIndexer(private val context: Context) {
   /**
    * Returns one document per launchable activity across all profiles. [pauseCheck] is invoked
    * between profiles and apps so indexing yields to active searches.
+   *
+   * When [packageNames] is set, only those packages are queried. An empty filter returns nothing
+   * without walking the full catalog.
    */
-  suspend fun buildDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
+  suspend fun buildDocuments(
+    pauseCheck: suspend () -> Unit,
+    packageNames: Collection<String>? = null,
+  ): List<AppSearchDocument> {
+    if (packageNames != null && packageNames.isEmpty()) return emptyList()
+
     val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
 
     val apps = mutableListOf<AppSearchDocument>()
@@ -31,7 +39,18 @@ class AppIndexer(private val context: Context) {
       try {
         // fetch activities directly per profile. This is more efficient and safer
         // than getInstalledPackages which is prone to DeadObjectException.
-        val activityList = launcherApps.getActivityList(null, profile)
+        val activityList =
+          if (packageNames == null) {
+            launcherApps.getActivityList(null, profile)
+          } else {
+            packageNames.flatMap { pkg ->
+              try {
+                launcherApps.getActivityList(pkg, profile)
+              } catch (_: Exception) {
+                emptyList()
+              }
+            }
+          }
 
         for (info in activityList) {
           pauseCheck()

--- a/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
@@ -39,9 +39,14 @@ class IconRepository(private val context: Context) {
 
   fun hasOnDisk(id: String): Boolean = File(getIconDir(), "${sanitizeId(id)}.png").exists()
 
-  fun saveToDisk(id: String, drawable: Drawable?, force: Boolean = true) {
-    if (drawable == null || !force) return
+  /**
+   * Writes [drawable] as a 192px PNG. Encoding is CPU-heavy, so [force] defaults to false and
+   * leaves an existing file alone. Pass [force] true only when the caller knows the icon changed.
+   */
+  fun saveToDisk(id: String, drawable: Drawable?, force: Boolean = false) {
+    if (drawable == null) return
     val targetFile = File(getIconDir(), "${sanitizeId(id)}.png")
+    if (!force && targetFile.exists() && targetFile.length() > 0) return
     val tmpFile = File(getIconDir(), "${sanitizeId(id)}.tmp")
 
     try {

--- a/app/src/main/java/com/searchlauncher/app/data/IndexingDispatchers.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/IndexingDispatchers.kt
@@ -1,0 +1,33 @@
+package com.searchlauncher.app.data
+
+import android.os.Process
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+
+/**
+ * Indexing is CPU- and Binder-heavy (PackageManager, AppSearch, bitmap encode). Running that work
+ * on [kotlinx.coroutines.Dispatchers.IO] at default thread priority lets it compete with the UI
+ * thread and with interactive search, which is why a "background" rebuild can still make typing
+ * feel sticky.
+ *
+ * A single background-priority thread keeps rebuilds off the interactive path and naturally
+ * serializes durable writes.
+ */
+object IndexingDispatchers {
+  private val threadCount = AtomicInteger()
+
+  val limited: CoroutineDispatcher =
+    Executors.newSingleThreadExecutor { runnable ->
+        Thread(
+            {
+              Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
+              runnable.run()
+            },
+            "search-index-${threadCount.incrementAndGet()}",
+          )
+          .apply { isDaemon = true }
+      }
+      .asCoroutineDispatcher()
+}

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -48,6 +48,8 @@ private const val USAGE_KEY_SEPARATOR = "\u001F"
 private const val QUERY_USAGE_FULL_QUERY_POINTS = 100
 private const val INDEXING_INTERACTIVE_SEARCH_PAUSE_MS = 1200L
 private const val INDEXING_INTERACTIVE_SEARCH_POLL_MS = 80L
+private const val APPSEARCH_PUT_BATCH_SIZE = 50
+private const val APPS_REFRESH_DEBOUNCE_MS = 750L
 
 /** Editing one contact fires several provider notifications; wait for the burst to settle. */
 private const val CONTACTS_REFRESH_DEBOUNCE_MS = 2000L
@@ -168,6 +170,22 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   }
 
   /**
+   * Replaces only the documents whose ids are in [replaceIds] inside [namespace], leaving every
+   * other namespace (and other ids in this one) searchable.
+   */
+  internal fun replaceDocumentsInNamespace(
+    namespace: String,
+    replaceIds: Set<String>,
+    documents: List<AppSearchDocument>,
+  ) {
+    synchronized(this) {
+      val filtered =
+        documentSnapshot.filter { it.doc.namespace != namespace || it.doc.id !in replaceIds }
+      documentSnapshot = (filtered + documents.map { wrap(it) }).sortedBy { it.namespaceInt }
+    }
+  }
+
+  /**
    * Indexing UI is only shown when search cannot serve an existing snapshot. Background rebuilds
    * keep the old index live and swap when ready, so users should not notice them.
    */
@@ -238,13 +256,26 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     }
   }
 
+  private suspend fun putDocuments(session: AppSearchSession, documents: List<AppSearchDocument>) {
+    if (documents.isEmpty()) return
+    documents.chunked(APPSEARCH_PUT_BATCH_SIZE).forEach { chunk ->
+      pauseIndexingIfSearchIsActive()
+      try {
+        session.putAsync(PutDocumentsRequest.Builder().addDocuments(chunk).build()).await()
+      } catch (e: Exception) {
+        android.util.Log.e("SearchRepository", "Failed to put batch of indexed documents", e)
+        Sentry.captureException(e)
+      }
+    }
+  }
+
   private val smartActionManager = SmartActionManager(context)
   private val contactActionsRepository = ContactActionsRepository(context)
   private val iconGenerator = SearchIconGenerator(context)
   private val iconRepository = IconRepository(context)
   private val searchResultFactory = SearchResultFactory(context, iconRepository, iconGenerator)
   private val appIndexer = AppIndexer(context)
-  private val shortcutIndexer = ShortcutIndexer(context, iconRepository)
+  private val shortcutIndexer = ShortcutIndexer(context)
   private val contactIndexer = ContactIndexer(context)
   private val snippetIndexer = SnippetIndexer(context)
 
@@ -433,6 +464,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             indexWriteMutex.withLock {
               val appsStart = System.currentTimeMillis()
               pauseIndexingIfSearchIsActive()
+              // Also refreshes dynamic and static shortcuts for the current catalog.
               indexApps()
               android.util.Log.d(
                 "SearchRepository",
@@ -445,14 +477,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
               android.util.Log.d(
                 "SearchRepository",
                 "indexCustomShortcuts took ${System.currentTimeMillis() - customStart}ms",
-              )
-
-              val staticStart = System.currentTimeMillis()
-              pauseIndexingIfSearchIsActive()
-              indexStaticShortcuts()
-              android.util.Log.d(
-                "SearchRepository",
-                "indexStaticShortcuts took ${System.currentTimeMillis() - staticStart}ms",
               )
 
               val contactsStart = System.currentTimeMillis()
@@ -595,39 +619,51 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       }
     }
 
-  private suspend fun indexApps() =
-    withContext(Dispatchers.IO) {
-      android.util.Log.d("SearchRepository", "Indexing apps...")
+  // packageNames: if null, full catalog rebuild; if provided, only those packages are queried
+  // and swapped. Package-changed callbacks used to rebuild every app, every shortcut, and every
+  // APK's static shortcuts — that is what made a single Play Store update hitch the UI.
+  private suspend fun indexApps(packageNames: List<String>? = null) =
+    withContext(IndexingDispatchers.limited) {
+      android.util.Log.d(
+        "SearchRepository",
+        if (packageNames == null) "Indexing apps..."
+        else "Indexing apps for ${packageNames.size} package(s)...",
+      )
       val session = appSearchSession ?: return@withContext
 
-      // Build against the live snapshot; put first, then remove stale ids, then atomic swap.
-      // The old in-memory apps collection stays searchable until replaceCollection runs.
-      val apps = appIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
+      val apps = appIndexer.buildDocuments(::pauseIndexingIfSearchIsActive, packageNames)
 
-      if (apps.isNotEmpty()) {
-        // Batch AppSearch puts to avoid TransactionTooLargeException
-        apps.chunked(50).forEach { chunk ->
-          val putRequest = PutDocumentsRequest.Builder().addDocuments(chunk).build()
+      if (packageNames == null) {
+        if (apps.isNotEmpty()) {
+          putDocuments(session, apps)
+          removeMissingDocuments(session, "apps", apps.map { it.id }.toSet())
+          replaceCollection("apps", apps)
+        } else {
+          android.util.Log.w(
+            "SearchRepository",
+            "indexApps: No apps found. Skipping update to prevent accidental wipe.",
+          )
+        }
+      } else {
+        val foundIds = apps.map { it.id }.toSet()
+        val removedIds = packageNames.filter { it !in foundIds }
+        putDocuments(session, apps)
+        if (removedIds.isNotEmpty()) {
           try {
-            session.putAsync(putRequest).await()
+            session
+              .removeAsync(RemoveByDocumentIdRequest.Builder("apps").addIds(removedIds).build())
+              .await()
           } catch (e: Exception) {
-            android.util.Log.e("SearchRepository", "Failed to put batch of indexed apps", e)
+            android.util.Log.e("SearchRepository", "Failed to remove uninstalled apps", e)
             Sentry.captureException(e)
           }
         }
-
-        removeMissingDocuments(session, "apps", apps.map { it.id }.toSet())
-        replaceCollection("apps", apps)
-      } else {
-        android.util.Log.w(
-          "SearchRepository",
-          "indexApps: No apps found. Skipping update to prevent accidental wipe.",
-        )
+        replaceDocumentsInNamespace("apps", packageNames.toSet(), apps)
       }
 
       try {
-        indexShortcuts(apps.map { it.id }.distinct())
-        indexStaticShortcuts() // Static shortcuts also change when apps are removed/added
+        indexShortcuts(packageNames)
+        indexStaticShortcuts(packageNames)
       } catch (e: Exception) {
         android.util.Log.e("SearchRepository", "Error updating shortcuts after indexApps", e)
         Sentry.captureException(e)
@@ -639,7 +675,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   // packageNames: if null, full re-index using all known apps; if provided, partial update for
   // just those packages (used by onShortcutsChanged to avoid re-querying every installed app).
   suspend fun indexShortcuts(packageNames: List<String>? = null) =
-    withContext(Dispatchers.IO) {
+    withContext(IndexingDispatchers.limited) {
       val session = appSearchSession ?: return@withContext
 
       val isFullReindex = packageNames == null
@@ -652,16 +688,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         shortcutIndexer.buildDynamicDocuments(packages, ::pauseIndexingIfSearchIsActive)
           ?: return@withContext
 
-      if (newShortcuts.isNotEmpty()) {
-        newShortcuts.chunked(50).forEach { chunk ->
-          try {
-            session.putAsync(PutDocumentsRequest.Builder().addDocuments(chunk).build()).await()
-          } catch (e: Exception) {
-            android.util.Log.e("SearchRepository", "Failed to put batch of indexed shortcuts", e)
-            Sentry.captureException(e)
-          }
-        }
-      }
+      putDocuments(session, newShortcuts)
 
       if (isFullReindex) {
         removeMissingDocuments(session, "shortcuts", newShortcuts.map { it.id }.toSet())
@@ -703,17 +730,13 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     }
 
   suspend fun indexCustomShortcuts() =
-    withContext(Dispatchers.IO) {
+    withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
 
       // Build first; put; remove stale; then atomically swap both namespaces in memory.
       val allDocs = shortcutIndexer.buildCustomDocuments()
-      pauseIndexingIfSearchIsActive()
-      if (allDocs.isNotEmpty()) {
-        val putRequest = PutDocumentsRequest.Builder().addDocuments(allDocs).build()
-        session.putAsync(putRequest).await()
-      }
+      putDocuments(session, allDocs)
 
       val searchShortcutIds =
         allDocs.asSequence().filter { it.namespace == "search_shortcuts" }.map { it.id }.toSet()
@@ -730,19 +753,52 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       )
     }
 
-  suspend fun indexStaticShortcuts() =
-    withContext(Dispatchers.IO) {
+  suspend fun indexStaticShortcuts(packageNames: List<String>? = null) =
+    withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
-      val docs = shortcutIndexer.buildStaticDocuments(::pauseIndexingIfSearchIsActive)
+      val docs = shortcutIndexer.buildStaticDocuments(::pauseIndexingIfSearchIsActive, packageNames)
 
-      pauseIndexingIfSearchIsActive()
-      if (docs.isNotEmpty()) {
-        val putRequest = PutDocumentsRequest.Builder().addDocuments(docs).build()
-        session.putAsync(putRequest).await()
+      putDocuments(session, docs)
+      if (packageNames == null) {
+        removeMissingDocuments(session, "static_shortcuts", docs.map { it.id }.toSet())
+        replaceCollection("static_shortcuts", docs)
+      } else {
+        val previousIds =
+          documentSnapshot
+            .asSequence()
+            .filter { sdoc ->
+              sdoc.doc.namespace == "static_shortcuts" &&
+                packageNames.any { sdoc.doc.id.startsWith("$it/") }
+            }
+            .map { it.doc.id }
+            .toSet()
+        val keepIds = docs.map { it.id }.toSet()
+        val staleIds = previousIds - keepIds
+        if (staleIds.isNotEmpty()) {
+          try {
+            session
+              .removeAsync(
+                RemoveByDocumentIdRequest.Builder("static_shortcuts").addIds(staleIds).build()
+              )
+              .await()
+          } catch (e: Exception) {
+            android.util.Log.e(
+              "SearchRepository",
+              "Failed to remove stale static shortcuts for packages",
+              e,
+            )
+          }
+        }
+        synchronized(this@SearchRepository) {
+          val filtered =
+            documentSnapshot.filter { sdoc ->
+              sdoc.doc.namespace != "static_shortcuts" ||
+                packageNames.none { sdoc.doc.id.startsWith("$it/") }
+            }
+          documentSnapshot = (filtered + docs.map { wrap(it) }).sortedBy { it.namespaceInt }
+        }
       }
-      removeMissingDocuments(session, "static_shortcuts", docs.map { it.id }.toSet())
-      replaceCollection("static_shortcuts", docs)
     }
 
   /** Coalesces the burst of change notifications an account sync produces into one rebuild. */
@@ -804,7 +860,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
     }
 
   suspend fun indexContacts() =
-    withContext(Dispatchers.IO) {
+    withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
       val permission = context.checkSelfPermission(android.Manifest.permission.READ_CONTACTS)
@@ -820,10 +876,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       val contacts = contactIndexer.buildDocuments(::pauseIndexingIfSearchIsActive)
 
       if (contacts.isNotEmpty()) {
-        pauseIndexingIfSearchIsActive()
         android.util.Log.d("SearchRepository", "Indexed ${contacts.size} contacts")
-        val putRequest = PutDocumentsRequest.Builder().addDocuments(contacts).build()
-        session.putAsync(putRequest).await()
+        putDocuments(session, contacts)
         removeMissingDocuments(session, "contacts", contacts.map { it.id }.toSet())
         replaceCollection("contacts", contacts)
         context
@@ -860,7 +914,6 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         indexWriteMutex.withLock {
           indexApps()
           indexCustomShortcuts()
-          indexStaticShortcuts()
           indexContacts()
           indexSnippets()
         }
@@ -914,10 +967,9 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             SetSchemaRequest.Builder().addDocumentClasses(AppSearchDocument::class.java).build()
           session.setSchemaAsync(initSchemaRequest).await()
 
-          // Re-index core only
+          // Re-index core only. indexApps also refreshes dynamic and static shortcuts.
           indexApps()
           indexCustomShortcuts()
-          indexStaticShortcuts()
         }
 
         // Reset first run flag and clear wallpaper URI to reveal system wallpaper
@@ -1293,26 +1345,44 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   private val scope = kotlinx.coroutines.CoroutineScope(Dispatchers.IO)
 
+  private val pendingAppPackages = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
+  @Volatile private var pendingFullAppReindex = false
+  private var appsRefreshJob: kotlinx.coroutines.Job? = null
+
+  private fun scheduleAppsRefresh(packageName: String? = null) {
+    if (packageName == null) pendingFullAppReindex = true
+    else pendingAppPackages[packageName] = true
+    if (appsRefreshJob?.isActive == true) return
+    appsRefreshJob =
+      scope.launch {
+        while (true) {
+          delay(APPS_REFRESH_DEBOUNCE_MS)
+          val full = pendingFullAppReindex
+          pendingFullAppReindex = false
+          val packages = pendingAppPackages.keys.toList()
+          pendingAppPackages.clear()
+          if (!full && packages.isEmpty()) break
+          indexWriteMutex.withLock { if (full) indexApps() else indexApps(packages) }
+        }
+      }
+  }
+
   private val launcherCallback =
     object : android.content.pm.LauncherApps.Callback() {
       override fun onPackageRemoved(packageName: String, user: android.os.UserHandle) {
         android.util.Log.d("SearchRepository", "onPackageRemoved: $packageName")
-        scope.launch { indexApps() }
+        scheduleAppsRefresh(packageName)
       }
 
       override fun onPackageAdded(packageName: String, user: android.os.UserHandle) {
         android.util.Log.d("SearchRepository", "onPackageAdded: $packageName")
-        scope.launch {
-          indexApps()
-          iconRepository.cacheAppIcon(packageName)
-        }
+        scheduleAppsRefresh(packageName)
+        scope.launch { iconRepository.cacheAppIcon(packageName) }
       }
 
       override fun onPackageChanged(packageName: String, user: android.os.UserHandle) {
-        scope.launch {
-          indexApps()
-          iconRepository.cacheAppIcon(packageName)
-        }
+        scheduleAppsRefresh(packageName)
+        scope.launch { iconRepository.cacheAppIcon(packageName) }
       }
 
       override fun onPackagesAvailable(
@@ -1320,7 +1390,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         user: android.os.UserHandle,
         replacing: Boolean,
       ) {
-        scope.launch { indexApps() }
+        if (packageNames.isNullOrEmpty()) scheduleAppsRefresh()
+        else packageNames.forEach { scheduleAppsRefresh(it) }
       }
 
       override fun onPackagesUnavailable(
@@ -1328,7 +1399,8 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         user: android.os.UserHandle,
         replacing: Boolean,
       ) {
-        scope.launch { indexApps() }
+        if (packageNames.isNullOrEmpty()) scheduleAppsRefresh()
+        else packageNames.forEach { scheduleAppsRefresh(it) }
       }
 
       override fun onShortcutsChanged(
@@ -1336,7 +1408,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         shortcuts: List<android.content.pm.ShortcutInfo>,
         user: android.os.UserHandle,
       ) {
-        scope.launch { indexShortcuts(listOf(packageName)) }
+        scope.launch { indexWriteMutex.withLock { indexShortcuts(listOf(packageName)) } }
       }
     }
 
@@ -1403,16 +1475,13 @@ class SearchRepository(private val context: Context) : BaseRepository() {
   // indexContacts - Removed
 
   suspend fun indexSnippets() =
-    withContext(Dispatchers.IO) {
+    withContext(IndexingDispatchers.limited) {
       pauseIndexingIfSearchIsActive()
       val session = appSearchSession ?: return@withContext
 
       try {
         val docs = snippetIndexer.buildDocuments()
-        if (docs.isNotEmpty()) {
-          val putRequest = PutDocumentsRequest.Builder().addDocuments(docs).build()
-          session.putAsync(putRequest).await()
-        }
+        putDocuments(session, docs)
         removeMissingDocuments(session, "snippets", docs.map { it.id }.toSet())
         replaceCollection("snippets", docs)
         android.util.Log.d("SearchRepository", "Indexed ${docs.size} snippets")

--- a/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchResultFactory.kt
@@ -280,10 +280,17 @@ class SearchResultFactory(
       val query = LauncherApps.ShortcutQuery()
       query.setPackage(sdoc.packageName ?: "")
       query.setShortcutIds(listOf(sdoc.doc.id.substringAfter("/")))
+      val cached =
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+          LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED
+        } else {
+          0
+        }
       query.setQueryFlags(
         LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
           LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-          LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED
+          LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
+          cached
       )
       val shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle())
       val icon =
@@ -405,7 +412,7 @@ class SearchResultFactory(
   private fun cacheIcon(cacheKey: String, icon: Drawable, saveToDisk: Boolean) {
     iconRepository.putMemory(cacheKey, icon)
     if (saveToDisk) {
-      iconRepository.saveToDisk(cacheKey, icon, force = true)
+      iconRepository.saveToDisk(cacheKey, icon)
     }
   }
 

--- a/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/ShortcutIndexer.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.pm.LauncherApps
 import com.searchlauncher.app.SearchLauncherApp
 import com.searchlauncher.app.util.StaticShortcutScanner
-import io.sentry.Sentry
 
 /**
  * Builds AppSearch documents for the three flavours of shortcut the launcher indexes:
@@ -12,14 +11,13 @@ import io.sentry.Sentry
  * - static shortcuts declared in app manifests (scanned by [StaticShortcutScanner])
  * - the launcher's own app actions and user-defined search shortcuts
  *
- * These are pure readers (aside from caching icons to disk as a side effect). Persisting the
- * documents is the caller's responsibility.
+ * These are pure readers. Persisting the documents (and loading icons when a result is shown) is
+ * the caller's responsibility.
  */
-class ShortcutIndexer(private val context: Context, private val iconRepository: IconRepository) {
+class ShortcutIndexer(private val context: Context) {
 
   /**
-   * Reads dynamic/manifest/pinned shortcuts for the given [packages] across all profiles and caches
-   * their icons to disk.
+   * Reads dynamic/manifest/pinned/cached shortcuts for the given [packages] across all profiles.
    *
    * Returns null if the system shortcut service became unavailable mid-scan (the caller should then
    * abandon the index update), otherwise the collected documents.
@@ -84,28 +82,9 @@ class ShortcutIndexer(private val context: Context, private val iconRepository: 
                   }
                 }
 
-              try {
-                val icon =
-                  launcherApps.getShortcutIconDrawable(
-                    shortcut,
-                    context.resources.displayMetrics.densityDpi,
-                  )
-                if (icon != null) {
-                  iconRepository.saveToDisk("shortcut_$shortcutId", icon, force = true)
-                }
-              } catch (e: Exception) {
-                // Ignore icon loading failures
-              }
-
-              val pkg = shortcut.`package`
-              if (!iconRepository.hasOnDisk("appicon_$pkg")) {
-                try {
-                  val appIcon = context.packageManager.getApplicationIcon(pkg)
-                  iconRepository.saveToDisk("appicon_$pkg", appIcon, force = true)
-                } catch (e: Exception) {
-                  // Ignore icon loading failures
-                }
-              }
+              // Icons are loaded lazily when a result is shown. Encoding every shortcut PNG here
+              // (chat apps publish hundreds of cached conversations) saturates CPU on the same
+              // pool search uses, which is what makes a "background" reindex feel sticky.
 
               newShortcuts.add(
                 AppSearchDocument(
@@ -134,9 +113,16 @@ class ShortcutIndexer(private val context: Context, private val iconRepository: 
     return newShortcuts
   }
 
-  /** Scans static (manifest-declared) shortcuts, caching their icons and app icons to disk. */
-  suspend fun buildStaticDocuments(pauseCheck: suspend () -> Unit): List<AppSearchDocument> {
-    val shortcuts = StaticShortcutScanner.scan(context)
+  /**
+   * Scans static (manifest-declared) shortcuts. When [packageNames] is set, only those packages are
+   * parsed — a full APK walk on every package-changed event is what made incremental updates as
+   * expensive as a full reindex.
+   */
+  suspend fun buildStaticDocuments(
+    pauseCheck: suspend () -> Unit,
+    packageNames: Collection<String>? = null,
+  ): List<AppSearchDocument> {
+    val shortcuts = StaticShortcutScanner.scan(context, packageNames)
     val docs = mutableListOf<AppSearchDocument>()
     for (s in shortcuts) {
       pauseCheck()
@@ -148,31 +134,7 @@ class ShortcutIndexer(private val context: Context, private val iconRepository: 
           s.packageName
         }
 
-      // Pre-load and cache static shortcut icon
       val shortcutId = "${s.packageName}/${s.id}"
-      try {
-        if (s.iconResId > 0) {
-          val res = context.packageManager.getResourcesForApplication(s.packageName)
-          val icon = res.getDrawable(s.iconResId.toInt(), null)
-          if (icon != null) {
-            iconRepository.saveToDisk("static_shortcut_$shortcutId", icon, force = true)
-          }
-        }
-      } catch (e: Exception) {
-        // Ignore icon loading failures
-        Sentry.captureException(e)
-      }
-
-      // Pre-load and cache app icon
-      if (!iconRepository.hasOnDisk("appicon_${s.packageName}")) {
-        try {
-          val appIcon = context.packageManager.getApplicationIcon(s.packageName)
-          iconRepository.saveToDisk("appicon_${s.packageName}", appIcon, force = true)
-        } catch (e: Exception) {
-          // Ignore app icon loading failures
-          Sentry.captureException(e)
-        }
-      }
 
       docs.add(
         AppSearchDocument(

--- a/app/src/main/java/com/searchlauncher/app/util/StaticShortcutScanner.kt
+++ b/app/src/main/java/com/searchlauncher/app/util/StaticShortcutScanner.kt
@@ -18,12 +18,21 @@ data class StaticShortcut(
 )
 
 object StaticShortcutScanner {
-  fun scan(context: Context): List<StaticShortcut> {
+  fun scan(context: Context, packageNames: Collection<String>? = null): List<StaticShortcut> {
+    if (packageNames != null && packageNames.isEmpty()) return emptyList()
+
     val shortcuts = mutableListOf<StaticShortcut>()
     val pm = context.packageManager
 
     val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
-    val activities = pm.queryIntentActivities(intent, PackageManager.GET_META_DATA)
+    val activities =
+      if (packageNames == null) {
+        pm.queryIntentActivities(intent, PackageManager.GET_META_DATA)
+      } else {
+        packageNames.flatMap { pkg ->
+          pm.queryIntentActivities(Intent(intent).setPackage(pkg), PackageManager.GET_META_DATA)
+        }
+      }
 
     for (resolveInfo in activities) {
       val activityInfo = resolveInfo.activityInfo ?: continue

--- a/app/src/test/java/com/searchlauncher/app/data/AppIndexerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/AppIndexerTest.kt
@@ -1,0 +1,25 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AppIndexerTest {
+
+  @Test
+  fun buildDocuments_emptyPackageFilterReturnsEmptyWithoutCatalogWalk() = runBlocking {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val indexer = AppIndexer(context)
+
+    val docs = indexer.buildDocuments(pauseCheck = {}, packageNames = emptyList())
+
+    assertTrue(docs.isEmpty())
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/IconRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/IconRepositoryTest.kt
@@ -1,0 +1,75 @@
+package com.searchlauncher.app.data
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class IconRepositoryTest {
+
+  private lateinit var context: Context
+  private lateinit var repository: IconRepository
+
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+    repository = IconRepository(context)
+    File(context.filesDir, "favorite_icons").deleteRecursively()
+  }
+
+  @Test
+  fun saveToDisk_writesWhenFileIsMissingEvenIfNotForced() {
+    repository.saveToDisk("new_icon", ColorDrawable(Color.RED), force = false)
+
+    val file = iconFile("new_icon")
+    assertTrue("Missing icons must still be written on the lazy path", file.exists())
+    assertTrue(file.length() > 0)
+  }
+
+  @Test
+  fun saveToDisk_skipsExistingFileWhenNotForced() {
+    repository.saveToDisk("cached_icon", ColorDrawable(Color.RED), force = true)
+    val file = iconFile("cached_icon")
+    val firstModified = file.lastModified()
+    val firstSize = file.length()
+
+    file.setLastModified(firstModified - 5_000)
+    val stampedModified = file.lastModified()
+
+    repository.saveToDisk("cached_icon", ColorDrawable(Color.BLUE), force = false)
+
+    assertEquals(
+      "Re-encoding an unchanged icon on every index pass is the CPU spike users feel",
+      stampedModified,
+      file.lastModified(),
+    )
+    assertEquals(firstSize, file.length())
+  }
+
+  @Test
+  fun saveToDisk_overwritesWhenForced() {
+    repository.saveToDisk("forced_icon", ColorDrawable(Color.RED), force = true)
+    val file = iconFile("forced_icon")
+    file.setLastModified(file.lastModified() - 5_000)
+    val stampedModified = file.lastModified()
+
+    repository.saveToDisk("forced_icon", ColorDrawable(Color.BLUE), force = true)
+
+    assertTrue(
+      "force=true must refresh an icon the caller knows changed",
+      file.lastModified() > stampedModified,
+    )
+  }
+
+  private fun iconFile(id: String) = File(context.filesDir, "favorite_icons/${id}.png")
+}

--- a/app/src/test/java/com/searchlauncher/app/data/IndexingDispatchersTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/IndexingDispatchersTest.kt
@@ -1,0 +1,27 @@
+package com.searchlauncher.app.data
+
+import android.os.Process
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class IndexingDispatchersTest {
+
+  @Test
+  fun limitedDispatcher_runsBelowDefaultPriority() = runBlocking {
+    val priority =
+      withContext(IndexingDispatchers.limited) { Process.getThreadPriority(Process.myTid()) }
+
+    assertTrue(
+      "Indexing must yield CPU to the UI thread; default-priority IO work is why background " +
+        "rebuilds still hitch typing",
+      priority >= Process.THREAD_PRIORITY_BACKGROUND,
+    )
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -166,6 +166,62 @@ class SearchRepositoryTest {
   }
 
   @Test
+  fun `replaceDocumentsInNamespace updates only the listed ids`() {
+    val maps =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.test.maps",
+        score = 1,
+        name = "Maps",
+        isAction = false,
+        iconResId = 0L,
+      )
+    val clock =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.test.clock",
+        score = 1,
+        name = "Clock",
+        isAction = false,
+        iconResId = 0L,
+      )
+    val contact =
+      AppSearchDocument(
+        namespace = "contacts",
+        id = "lookup/1",
+        score = 1,
+        name = "Ada",
+        description = "|555",
+        isAction = false,
+        iconResId = 0L,
+      )
+    val updatedClock =
+      AppSearchDocument(
+        namespace = "apps",
+        id = "com.test.clock",
+        score = 1,
+        name = "Desk Clock",
+        isAction = false,
+        iconResId = 0L,
+      )
+
+    repository.documentSnapshot =
+      listOf(repository.wrap(maps), repository.wrap(clock), repository.wrap(contact)).sortedBy {
+        it.namespaceInt
+      }
+
+    repository.replaceDocumentsInNamespace("apps", setOf(clock.id), listOf(updatedClock))
+
+    assertEquals(
+      listOf("com.test.maps", "com.test.clock", "lookup/1"),
+      repository.documentSnapshot.map { it.doc.id },
+    )
+    assertEquals("Desk Clock", repository.documentSnapshot.first { it.doc.id == clock.id }.doc.name)
+    assertEquals("Maps", repository.documentSnapshot.first { it.doc.id == maps.id }.doc.name)
+    assertTrue(repository.documentSnapshot.any { it.doc.namespace == "contacts" })
+  }
+
+  @Test
   fun `getResults resolves namespaced favorite keys in order`() = runBlocking {
     // Same bare id in two namespaces — resolution must use the namespace from the key.
     val app =

--- a/app/src/test/java/com/searchlauncher/app/util/StaticShortcutScannerTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/util/StaticShortcutScannerTest.kt
@@ -10,7 +10,9 @@ import android.content.res.XmlResourceParser
 import android.os.Bundle
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -103,5 +105,17 @@ class StaticShortcutScannerTest {
     assertEquals("shortcut_1", results[0].id)
     assertEquals("My Shortcut", results[0].shortLabel)
     assertEquals("android.intent.action.VIEW", results[0].intent.action)
+  }
+
+  @Test
+  fun scan_emptyPackageFilterDoesNotQueryInstalledApps() {
+    val context = mockk<Context>(relaxed = true)
+    val pm = mockk<PackageManager>()
+    every { context.packageManager } returns pm
+
+    val results = StaticShortcutScanner.scan(context, emptyList())
+
+    assertTrue(results.isEmpty())
+    verify(exactly = 0) { pm.queryIntentActivities(any(), any<Int>()) }
   }
 }

--- a/fastlane/metadata/android/en-US/changelogs/254.txt
+++ b/fastlane/metadata/android/en-US/changelogs/254.txt
@@ -1,0 +1,3 @@
+Background indexing no longer fights you for the CPU.
+
+Rebuilding the search index used to hitch typing even though it ran on another thread. It now runs at background priority, only refreshes apps that actually changed, and no longer re-encodes every shortcut icon on each pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was going wrong

Indexing already ran on `Dispatchers.IO`, not the main thread. That is not enough. A “background” rebuild still made the launcher hitch because the work competed with typing for CPU, Binder, and the shared IO pool.

The expensive parts were:

1. **Default thread priority.** `Dispatchers.IO` threads run at `THREAD_PRIORITY_DEFAULT`, the same niceness as the UI thread. PNG encode, AppSearch puts, and PackageManager Binder calls therefore schedule equally with composition and input.
2. **Full-catalog rebuilds on every package event.** `onPackageAdded` / `Changed` / `Removed` called `indexApps()`, which re-queried every launchable app, every dynamic shortcut, and parsed every APK’s static-shortcut XML. Play Store updates and chat-app shortcut churn triggered this often.
3. **Forced icon re-encoding.** Shortcut indexing called `saveToDisk(..., force = true)` for every shortcut. After cached-conversation indexing landed, a chat app can publish hundreds of shortcuts. Each one rasterized a 192px bitmap and PNG-compressed it. `force = false` previously meant “never write,” so every caller had to pass `true`.
4. **Duplicate static-shortcut scan.** The scheduled rebuild called `indexApps()` (which already refreshes static shortcuts) and then `indexStaticShortcuts()` again.
5. **Unchunked contact puts.** Apps were batched at 50 documents; contacts were written in one AppSearch transaction.

Search itself is in-memory and does not need AppSearch during typing. The hitch came from the rebuild stealing cores and Binder threads, not from the search query.

## What changed

- Rebuilds run on a single `THREAD_PRIORITY_BACKGROUND` dispatcher (`IndexingDispatchers.limited`) so the scheduler prefers the UI and interactive search.
- Package callbacks debounce (750ms) and refresh only the packages that changed. The live snapshot still swaps atomically per namespace.
- Shortcut/static-shortcut indexing no longer PNG-encodes icons. `SearchResultItem` already loads icons lazily; the on-demand path now also matches cached shortcuts so conversation icons still appear.
- `saveToDisk` skips an existing file unless the caller passes `force = true`.
- Contact (and other) AppSearch puts use the same 50-document batches as apps, and yield if a search is in progress between batches.
- The extra full static-shortcut scan on scheduled/reset rebuilds is gone.

## Release

CI on this PR succeeded. Version is now **0.0.16** (`versionCode` 254), tagged `v0.0.16`. F-Droid `AutoUpdateMode: Version` should pick the tag up on its own. The tag also starts the GitHub Release job that publishes `app-release.apk`.

## Tests

`./gradlew test` and `./gradlew spotlessCheck` both passed: **113 debug unit tests, 0 failures**.

New / focused coverage:

- `IconRepository`: skip-if-exists vs forced overwrite
- `SearchRepository.replaceDocumentsInNamespace`: incremental snapshot swap
- `StaticShortcutScanner` / `AppIndexer`: empty package filter does not walk the catalog
- `IndexingDispatchers`: worker thread is at background priority

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dda2d73-37fe-40ce-bcb8-c1f1bbb31fbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dda2d73-37fe-40ce-bcb8-c1f1bbb31fbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

