### PR TITLE
Fix indexing races Bugbot caught after merge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     // F-Droid greps these two literals out of this file to notice new release tags, so
     // they have to stay plain literals and be bumped in the commit that gets tagged. The series
     // starts at 250 to clear 242, the highest the old commit-count scheme ever shipped.
-    versionCode = 254
-    versionName = "0.0.16"
+    versionCode = 255
+    versionName = "0.0.17"
 
     buildConfigField("String", "GIT_HASH", "\"$gitHash\"")
     buildConfigField("String", "BUILD_DATE", "\"$buildDate\"")

--- a/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/IconRepository.kt
@@ -128,6 +128,29 @@ class IconRepository(private val context: Context) {
     clearMemory()
   }
 
+  /**
+   * Drops cached shortcut artwork for [packageName] so the next search reloads it from
+   * LauncherApps. Package updates and `onShortcutsChanged` change icons without changing ids, and
+   * [saveToDisk] will otherwise keep serving the old PNG forever.
+   */
+  fun invalidateShortcutIcons(packageName: String) {
+    val diskPrefixShortcut = "shortcut_${sanitizeId("$packageName/")}"
+    val diskPrefixStatic = "static_shortcut_${sanitizeId("$packageName/")}"
+    getIconDir().listFiles()?.forEach { file ->
+      val name = file.nameWithoutExtension
+      if (name.startsWith(diskPrefixShortcut) || name.startsWith(diskPrefixStatic)) {
+        file.delete()
+      }
+    }
+    val memoryPrefixShortcut = "shortcut_$packageName/"
+    val memoryPrefixStatic = "static_shortcut_$packageName/"
+    memoryCache.snapshot().keys.forEach { key ->
+      if (key.startsWith(memoryPrefixShortcut) || key.startsWith(memoryPrefixStatic)) {
+        memoryCache.remove(key)
+      }
+    }
+  }
+
   private fun getIconDir() = File(context.filesDir, "favorite_icons").apply { mkdirs() }
 
   private fun sanitizeId(id: String) = id.replace("/", "_").replace(":", "_")

--- a/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
+++ b/app/src/main/java/com/searchlauncher/app/data/SearchRepository.kt
@@ -646,7 +646,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         }
       } else {
         val foundIds = apps.map { it.id }.toSet()
-        val removedIds = packageNames.filter { it !in foundIds }
+        val missingIds = packageNames.filter { it !in foundIds }
+        // AppIndexer maps per-package query failures to an empty list, so "not in foundIds" is not
+        // the same as "uninstalled". Only drop packages we can confirm are gone.
+        val removedIds = missingIds.filterNot { isPackagePresent(it) }
         putDocuments(session, apps)
         if (removedIds.isNotEmpty()) {
           try {
@@ -658,7 +661,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
             Sentry.captureException(e)
           }
         }
-        replaceDocumentsInNamespace("apps", packageNames.toSet(), apps)
+        replaceDocumentsInNamespace("apps", (foundIds + removedIds).toSet(), apps)
       }
 
       try {
@@ -1347,24 +1350,74 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
   private val pendingAppPackages = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
   @Volatile private var pendingFullAppReindex = false
+  private val appsRefreshGuard = Any()
+  @Volatile private var appsRefreshRunning = false
   private var appsRefreshJob: kotlinx.coroutines.Job? = null
 
+  /**
+   * Coalesces launcher package events. A job that drains pending state and then exits can lose an
+   * event that arrived after the drain but while the job was still marked active; enqueue and
+   * "should I start a worker?" share [appsRefreshGuard], and the worker restarts from `finally` if
+   * anything landed during shutdown.
+   */
   private fun scheduleAppsRefresh(packageName: String? = null) {
-    if (packageName == null) pendingFullAppReindex = true
-    else pendingAppPackages[packageName] = true
-    if (appsRefreshJob?.isActive == true) return
-    appsRefreshJob =
-      scope.launch {
-        while (true) {
-          delay(APPS_REFRESH_DEBOUNCE_MS)
-          val full = pendingFullAppReindex
-          pendingFullAppReindex = false
-          val packages = pendingAppPackages.keys.toList()
-          pendingAppPackages.clear()
-          if (!full && packages.isEmpty()) break
-          indexWriteMutex.withLock { if (full) indexApps() else indexApps(packages) }
+    synchronized(appsRefreshGuard) {
+      if (packageName == null) pendingFullAppReindex = true
+      else pendingAppPackages[packageName] = true
+      if (appsRefreshRunning) return
+      appsRefreshRunning = true
+      appsRefreshJob = scope.launch { drainAppsRefresh() }
+    }
+  }
+
+  private suspend fun drainAppsRefresh() {
+    try {
+      while (true) {
+        delay(APPS_REFRESH_DEBOUNCE_MS)
+        val (full, packages) =
+          synchronized(appsRefreshGuard) {
+            val drainedFull = pendingFullAppReindex
+            pendingFullAppReindex = false
+            val drainedPackages = pendingAppPackages.keys.toList()
+            pendingAppPackages.clear()
+            drainedFull to drainedPackages
+          }
+        if (!full && packages.isEmpty()) return
+        indexWriteMutex.withLock { if (full) indexApps() else indexApps(packages) }
+      }
+    } finally {
+      synchronized(appsRefreshGuard) {
+        if (pendingFullAppReindex || pendingAppPackages.isNotEmpty()) {
+          appsRefreshJob = scope.launch { drainAppsRefresh() }
+        } else {
+          appsRefreshRunning = false
         }
       }
+    }
+  }
+
+  /**
+   * True when [packageName] is still installed for any profile we can see. Binder failures return
+   * true so a transient PackageManager error cannot wipe a still-installed app from search.
+   */
+  internal fun isPackagePresent(packageName: String): Boolean {
+    val launcherApps =
+      context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as android.content.pm.LauncherApps
+    for (profile in launcherApps.profiles) {
+      try {
+        if (launcherApps.isPackageEnabled(packageName, profile)) return true
+      } catch (_: Exception) {
+        // Not installed for this profile, or the query failed — try the next one.
+      }
+    }
+    return try {
+      context.packageManager.getApplicationInfo(packageName, 0)
+      true
+    } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
+      false
+    } catch (_: Exception) {
+      true
+    }
   }
 
   private val launcherCallback =
@@ -1372,6 +1425,7 @@ class SearchRepository(private val context: Context) : BaseRepository() {
       override fun onPackageRemoved(packageName: String, user: android.os.UserHandle) {
         android.util.Log.d("SearchRepository", "onPackageRemoved: $packageName")
         scheduleAppsRefresh(packageName)
+        iconRepository.invalidateShortcutIcons(packageName)
       }
 
       override fun onPackageAdded(packageName: String, user: android.os.UserHandle) {
@@ -1382,7 +1436,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
 
       override fun onPackageChanged(packageName: String, user: android.os.UserHandle) {
         scheduleAppsRefresh(packageName)
-        scope.launch { iconRepository.cacheAppIcon(packageName) }
+        scope.launch {
+          iconRepository.cacheAppIcon(packageName)
+          iconRepository.invalidateShortcutIcons(packageName)
+        }
       }
 
       override fun onPackagesAvailable(
@@ -1408,7 +1465,10 @@ class SearchRepository(private val context: Context) : BaseRepository() {
         shortcuts: List<android.content.pm.ShortcutInfo>,
         user: android.os.UserHandle,
       ) {
-        scope.launch { indexWriteMutex.withLock { indexShortcuts(listOf(packageName)) } }
+        scope.launch {
+          iconRepository.invalidateShortcutIcons(packageName)
+          indexWriteMutex.withLock { indexShortcuts(listOf(packageName)) }
+        }
       }
     }
 

--- a/app/src/test/java/com/searchlauncher/app/data/IconRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/IconRepositoryTest.kt
@@ -71,5 +71,34 @@ class IconRepositoryTest {
     )
   }
 
+  @Test
+  fun invalidateShortcutIcons_dropsOnlyThatPackage() {
+    repository.saveToDisk("shortcut_com.chat.app/conv1", ColorDrawable(Color.RED), force = true)
+    repository.saveToDisk(
+      "static_shortcut_com.chat.app/settings",
+      ColorDrawable(Color.GREEN),
+      force = true,
+    )
+    repository.saveToDisk("shortcut_com.other.app/conv1", ColorDrawable(Color.BLUE), force = true)
+    repository.saveToDisk("appicon_com.chat.app", ColorDrawable(Color.YELLOW), force = true)
+    repository.putMemory("shortcut_com.chat.app/conv1", ColorDrawable(Color.RED))
+    repository.putMemory("shortcut_com.other.app/conv1", ColorDrawable(Color.BLUE))
+
+    repository.invalidateShortcutIcons("com.chat.app")
+
+    assertTrue(!iconFile("shortcut_com.chat.app_conv1").exists())
+    assertTrue(!iconFile("static_shortcut_com.chat.app_settings").exists())
+    assertTrue(
+      "Other packages' shortcut icons must survive",
+      iconFile("shortcut_com.other.app_conv1").exists(),
+    )
+    assertTrue(
+      "App icons are refreshed separately via cacheAppIcon(force=true)",
+      iconFile("appicon_com.chat.app").exists(),
+    )
+    assertTrue(repository.getMemory("shortcut_com.chat.app/conv1") == null)
+    assertTrue(repository.getMemory("shortcut_com.other.app/conv1") != null)
+  }
+
   private fun iconFile(id: String) = File(context.filesDir, "favorite_icons/${id}.png")
 }

--- a/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/data/SearchRepositoryTest.kt
@@ -222,6 +222,18 @@ class SearchRepositoryTest {
   }
 
   @Test
+  fun `isPackagePresent keeps installed packages after a failed launcher query`() {
+    assertTrue(
+      "A still-installed package must not be treated as uninstalled when getActivityList fails",
+      repository.isPackagePresent(context.packageName),
+    )
+    assertFalse(
+      "A package that PackageManager cannot see is gone",
+      repository.isPackagePresent("com.missing.app.that.does.not.exist"),
+    )
+  }
+
+  @Test
   fun `getResults resolves namespaced favorite keys in order`() = runBlocking {
     // Same bare id in two namespaces — resolution must use the namespace from the key.
     val app =

--- a/fastlane/metadata/android/en-US/changelogs/255.txt
+++ b/fastlane/metadata/android/en-US/changelogs/255.txt
@@ -1,0 +1,5 @@
+Fixes on top of the quieter background indexing in 0.0.16.
+
+- Installing, updating, or uninstalling an app no longer gets lost if it happens while a refresh is already running.
+- A glitch talking to the system while an app updates can no longer hide that app from search.
+- Shortcut and conversation icons refresh when the app changes them, instead of staying stuck on the first artwork we cached.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up for the three Bugbot findings on the already-merged indexing PR.

## Debounce dropped package events

`scheduleAppsRefresh` recorded a package then returned whenever a worker was still marked active. If that event arrived after pending state was drained and the worker then exited, the install/update/uninstall never reached the index.

Enqueue and “should I start a worker?” now share a lock, and the worker restarts from `finally` if anything landed during shutdown. Cancel-and-reschedule is avoided because it would abort an in-flight `indexApps()`.

## Transient query failure removed apps

Incremental `indexApps` treated “not returned by `buildDocuments`” as uninstalled. `AppIndexer` already maps per-package exceptions to an empty list, so a Binder failure during an update could wipe a still-installed app.

Packages are now removed only when `isPackagePresent` confirms they are gone. Failures fail safe (keep the existing entry). The live snapshot is swapped only for packages we actually found or confirmed removed.

## Shortcut icons froze after updates

Indexing no longer writes shortcut PNGs, and `saveToDisk` skips existing files. Package/shortcut change callbacks never dropped `shortcut_*` / `static_shortcut_*` caches, so conversation artwork never refreshed.

`invalidateShortcutIcons` now runs on package change, removal, and `onShortcutsChanged`, so the next search reloads from LauncherApps.

## Release

CI on this PR succeeded. Version is now **0.0.17** (`versionCode` 255), tagged `v0.0.17`. F-Droid `AutoUpdateMode: Version` should pick the tag up on its own. The tag also starts the GitHub Release job that publishes `app-release.apk`.

## Tests

`./gradlew test` and `./gradlew spotlessCheck` passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dda2d73-37fe-40ce-bcb8-c1f1bbb31fbf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dda2d73-37fe-40ce-bcb8-c1f1bbb31fbf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

