### PR TITLE
Ask before a tab uses the microphone, camera, or other device access

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -27,6 +27,7 @@ SearchLauncher can open web results in its own browser instead of handing them t
 - **History and bookmarks** are stored locally so you can search them from the search bar. You can clear history and remove bookmarks in **Settings → Browser**.
 - **Site icons** are saved from the pages you visit; they are not requested from any third-party icon service.
 - **Cookies and site data** are handled by Android's system WebView. A private window keeps its cookies and storage in a separate area and wipes them when you close it.
+- **Microphone, camera, location, Bluetooth, and similar device access** is only granted after a site asks and you allow it. That choice is stored on the device for that site (or kept only in memory in a private window). Matching system permissions are requested if the app does not already have them.
 
 Pages you open naturally contact the servers of the sites you are visiting, exactly as any browser would. Those sites' own privacy policies apply.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,32 @@
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="31" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_CONNECT"
+        tools:targetApi="31" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADVERTISE"
+        tools:targetApi="31" />
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <application
         android:name=".SearchLauncherApp"

--- a/app/src/main/assets/PRIVACY.md
+++ b/app/src/main/assets/PRIVACY.md
@@ -27,6 +27,7 @@ SearchLauncher can open web results in its own browser instead of handing them t
 - **History and bookmarks** are stored locally so you can search them from the search bar. You can clear history and remove bookmarks in **Settings → Browser**.
 - **Site icons** are saved from the pages you visit; they are not requested from any third-party icon service.
 - **Cookies and site data** are handled by Android's system WebView. A private window keeps its cookies and storage in a separate area and wipes them when you close it.
+- **Microphone, camera, location, Bluetooth, and similar device access** is only granted after a site asks and you allow it. That choice is stored on the device for that site (or kept only in memory in a private window). Matching system permissions are requested if the app does not already have them.
 
 Pages you open naturally contact the servers of the sites you are visiting, exactly as any browser would. Those sites' own privacy policies apply.
 

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserActivity.kt
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
@@ -15,6 +16,8 @@ import android.os.Environment
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
+import android.webkit.GeolocationPermissions
+import android.webkit.PermissionRequest
 import android.webkit.URLUtil
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -26,8 +29,10 @@ import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.animateColorAsState
@@ -311,6 +316,40 @@ private data class LinkMenuTarget(val linkUrl: String?, val imageUrl: String?)
 /** A bookmark awaiting title confirmation in [BookmarkDialog]. */
 private data class BookmarkDraft(val url: String, val title: String)
 
+/**
+ * A page's device-access request, held while the site prompt or the matching OS permission is
+ * showing. WebView requires grant()/deny() (or the geolocation callback) exactly once.
+ */
+private sealed interface PendingDeviceAccess {
+  val origin: String
+  val asking: List<BrowserDeviceAccess>
+  val showSitePrompt: Boolean
+
+  data class WebResources(
+    val request: PermissionRequest,
+    override val origin: String,
+    val resources: Array<String>,
+    override val asking: List<BrowserDeviceAccess>,
+    override val showSitePrompt: Boolean,
+  ) : PendingDeviceAccess
+
+  data class Geolocation(
+    val callback: GeolocationPermissions.Callback,
+    val callbackOrigin: String,
+    override val origin: String,
+    override val asking: List<BrowserDeviceAccess> = listOf(BrowserDeviceAccess.LOCATION),
+    override val showSitePrompt: Boolean,
+  ) : PendingDeviceAccess
+}
+
+private fun PendingDeviceAccess.isSameRequestAs(other: PendingDeviceAccess?): Boolean =
+  when (this) {
+    is PendingDeviceAccess.WebResources ->
+      other is PendingDeviceAccess.WebResources && request === other.request
+    is PendingDeviceAccess.Geolocation ->
+      other is PendingDeviceAccess.Geolocation && callback === other.callback
+  }
+
 @OptIn(ExperimentalLayoutApi::class)
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -435,6 +474,191 @@ internal fun BrowserScreen(
   var bookmarkDraft by remember { mutableStateOf<BookmarkDraft?>(null) }
   val siteSettingsStore = remember(privateMode) { BrowserSiteSettingsStore(context, privateMode) }
   var siteSettings by remember { mutableStateOf(siteSettingsStore.load(activeTab.url)) }
+  var pendingAccess by remember { mutableStateOf<PendingDeviceAccess?>(null) }
+  var osAwaitingAccess by remember { mutableStateOf<PendingDeviceAccess?>(null) }
+
+  fun denyPendingAccess() {
+    val pending = pendingAccess
+    pendingAccess = null
+    osAwaitingAccess = null
+    when (pending) {
+      is PendingDeviceAccess.WebResources -> runCatching { pending.request.deny() }
+      is PendingDeviceAccess.Geolocation ->
+        runCatching { pending.callback.invoke(pending.callbackOrigin, false, false) }
+      null -> Unit
+    }
+  }
+
+  fun settlePendingAccess(pending: PendingDeviceAccess, grant: Boolean) {
+    if (pending.isSameRequestAs(pendingAccess)) pendingAccess = null
+    if (pending.isSameRequestAs(osAwaitingAccess)) osAwaitingAccess = null
+    when (pending) {
+      is PendingDeviceAccess.WebResources ->
+        if (grant && pending.resources.isNotEmpty()) {
+          runCatching { pending.request.grant(pending.resources) }
+        } else {
+          runCatching { pending.request.deny() }
+        }
+      is PendingDeviceAccess.Geolocation ->
+        runCatching { pending.callback.invoke(pending.callbackOrigin, grant, grant) }
+    }
+  }
+
+  fun persistDeviceAccess(
+    origin: String,
+    types: Collection<BrowserDeviceAccess>,
+    allowed: Boolean,
+  ) {
+    val updated = siteSettingsStore.load(origin).withAllowed(types, allowed)
+    siteSettingsStore.save(origin, updated)
+    if (browserOrigin(webView?.url ?: activeTab.url) == origin) {
+      siteSettings = updated
+    }
+  }
+
+  fun resourcesPermittedByOs(resources: Array<String>): Array<String> =
+    resources
+      .filter { resource ->
+        androidPermissionsForResources(arrayOf(resource)).all { permission ->
+          context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+        }
+      }
+      .toTypedArray()
+
+  val devicePermissionLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+      results ->
+      val pending = osAwaitingAccess ?: return@rememberLauncherForActivityResult
+      osAwaitingAccess = null
+      if (!pending.isSameRequestAs(pendingAccess)) return@rememberLauncherForActivityResult
+      when (pending) {
+        is PendingDeviceAccess.WebResources -> {
+          val granted = resourcesPermittedByOs(pending.resources)
+          if (granted.isEmpty()) {
+            settlePendingAccess(pending, grant = false)
+            if (results.values.any { !it }) {
+              Toast.makeText(context, "Permission is needed", Toast.LENGTH_SHORT).show()
+            }
+          } else {
+            settlePendingAccess(pending.copy(resources = granted), grant = true)
+          }
+        }
+        is PendingDeviceAccess.Geolocation -> {
+          val allowed =
+            androidPermissionsFor(listOf(BrowserDeviceAccess.LOCATION)).all { permission ->
+              context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+            }
+          settlePendingAccess(pending, grant = allowed)
+          if (!allowed) {
+            Toast.makeText(context, "Location permission is needed", Toast.LENGTH_SHORT).show()
+          }
+        }
+      }
+    }
+
+  fun grantAccessIfOsAllows(pending: PendingDeviceAccess) {
+    val needed =
+      when (pending) {
+        is PendingDeviceAccess.WebResources -> androidPermissionsForResources(pending.resources)
+        is PendingDeviceAccess.Geolocation ->
+          androidPermissionsFor(listOf(BrowserDeviceAccess.LOCATION))
+      }
+    val missing =
+      needed.filter { context.checkSelfPermission(it) != PackageManager.PERMISSION_GRANTED }
+    if (missing.isEmpty()) {
+      settlePendingAccess(pending, grant = true)
+    } else {
+      val waiting =
+        when (pending) {
+          is PendingDeviceAccess.WebResources -> pending.copy(showSitePrompt = false)
+          is PendingDeviceAccess.Geolocation -> pending.copy(showSitePrompt = false)
+        }
+      pendingAccess = waiting
+      osAwaitingAccess = waiting
+      devicePermissionLauncher.launch(missing.toTypedArray())
+    }
+  }
+
+  val onWebPermissionRequest by rememberUpdatedState { request: PermissionRequest ->
+    val origin = request.origin?.let { browserOrigin(it.toString()) }
+    if (origin == null) {
+      request.deny()
+    } else {
+      denyPendingAccess()
+      val settings = siteSettingsStore.load(origin)
+      val decision = decideWebResources(request.resources) { settings.allowed(it) }
+      if (decision.ask.isNotEmpty()) {
+        pendingAccess =
+          PendingDeviceAccess.WebResources(
+            request = request,
+            origin = origin,
+            resources = request.resources,
+            asking = decision.ask,
+            showSitePrompt = true,
+          )
+      } else {
+        val grant = decision.grantNow.toTypedArray()
+        if (grant.isEmpty()) {
+          request.deny()
+        } else {
+          grantAccessIfOsAllows(
+            PendingDeviceAccess.WebResources(
+              request = request,
+              origin = origin,
+              resources = grant,
+              asking = emptyList(),
+              showSitePrompt = false,
+            )
+          )
+        }
+      }
+    }
+  }
+  val onWebPermissionRequestCanceled by rememberUpdatedState { request: PermissionRequest ->
+    val pending = pendingAccess
+    if (pending is PendingDeviceAccess.WebResources && pending.request === request) {
+      pendingAccess = null
+      osAwaitingAccess = null
+    }
+  }
+  val onGeolocationPrompt by rememberUpdatedState {
+    originUrl: String,
+    callback: GeolocationPermissions.Callback ->
+    val origin = browserOrigin(originUrl)
+    if (origin == null) {
+      callback.invoke(originUrl, false, false)
+    } else {
+      denyPendingAccess()
+      when (siteSettingsStore.load(origin).allowed(BrowserDeviceAccess.LOCATION)) {
+        false -> callback.invoke(origin, false, true)
+        true ->
+          grantAccessIfOsAllows(
+            PendingDeviceAccess.Geolocation(
+              callback = callback,
+              callbackOrigin = originUrl,
+              origin = origin,
+              showSitePrompt = false,
+            )
+          )
+        null ->
+          pendingAccess =
+            PendingDeviceAccess.Geolocation(
+              callback = callback,
+              callbackOrigin = originUrl,
+              origin = origin,
+              showSitePrompt = true,
+            )
+      }
+    }
+  }
+  val onGeolocationPromptCanceled by rememberUpdatedState {
+    val pending = pendingAccess
+    if (pending is PendingDeviceAccess.Geolocation) {
+      pendingAccess = null
+      osAwaitingAccess = null
+    }
+  }
+
   var pageBackground by remember { mutableStateOf(Color(activeTab.pageBackgroundArgb)) }
   var fullscreenVideoView by remember { mutableStateOf<View?>(null) }
   var fullscreenVideoCallback by remember {
@@ -1120,6 +1344,7 @@ internal fun BrowserScreen(
                 )
               settings.javaScriptEnabled = true
               settings.domStorageEnabled = true
+              settings.setGeolocationEnabled(true)
               settings.setSupportZoom(true)
               settings.builtInZoomControls = true
               settings.displayZoomControls = false
@@ -1210,6 +1435,31 @@ internal fun BrowserScreen(
                     (context as ComponentActivity).lifecycleScope.launch {
                       repository.saveFavicon(pageUrl, pageIcon)
                     }
+                  }
+
+                  // Without this, getUserMedia and similar APIs are denied silently.
+                  override fun onPermissionRequest(request: PermissionRequest) {
+                    onWebPermissionRequest(request)
+                  }
+
+                  override fun onPermissionRequestCanceled(request: PermissionRequest) {
+                    onWebPermissionRequestCanceled(request)
+                  }
+
+                  override fun onGeolocationPermissionsShowPrompt(
+                    origin: String?,
+                    callback: GeolocationPermissions.Callback?,
+                  ) {
+                    if (callback == null) return
+                    if (origin == null) {
+                      callback.invoke("", false, false)
+                      return
+                    }
+                    onGeolocationPrompt(origin, callback)
+                  }
+
+                  override fun onGeolocationPermissionsHidePrompt() {
+                    onGeolocationPromptCanceled()
                   }
                 }
               webViewClient =
@@ -1385,6 +1635,7 @@ internal fun BrowserScreen(
           },
           onRelease = { releasedWebView ->
             if (webView === releasedWebView) webView = null
+            denyPendingAccess()
             releasedWebView.destroy()
           },
         )
@@ -1678,8 +1929,65 @@ internal fun BrowserScreen(
     )
   }
 
+  pendingAccess
+    ?.takeIf { it.showSitePrompt }
+    ?.let { pending ->
+      BrowserDeviceAccessDialog(
+        siteLabel = browserSiteLabel(pending.origin),
+        types = pending.asking,
+        onAllow = {
+          persistDeviceAccess(pending.origin, pending.asking, true)
+          when (pending) {
+            is PendingDeviceAccess.WebResources -> {
+              val grant =
+                grantableWebResources(pending.resources) {
+                  siteSettingsStore.load(pending.origin).allowed(it)
+                }
+              grantAccessIfOsAllows(pending.copy(resources = grant, showSitePrompt = false))
+            }
+            is PendingDeviceAccess.Geolocation ->
+              grantAccessIfOsAllows(pending.copy(showSitePrompt = false))
+          }
+        },
+        onBlock = {
+          persistDeviceAccess(pending.origin, pending.asking, false)
+          when (pending) {
+            is PendingDeviceAccess.WebResources -> {
+              val grant =
+                grantableWebResources(pending.resources) {
+                  siteSettingsStore.load(pending.origin).allowed(it)
+                }
+              if (grant.isEmpty()) {
+                settlePendingAccess(pending, grant = false)
+              } else {
+                grantAccessIfOsAllows(pending.copy(resources = grant, showSitePrompt = false))
+              }
+            }
+            is PendingDeviceAccess.Geolocation -> settlePendingAccess(pending, grant = false)
+          }
+        },
+        onDismiss = {
+          when (pending) {
+            is PendingDeviceAccess.WebResources -> {
+              val grant =
+                grantableWebResources(pending.resources) {
+                  siteSettingsStore.load(pending.origin).allowed(it)
+                }
+              if (grant.isEmpty()) {
+                denyPendingAccess()
+              } else {
+                grantAccessIfOsAllows(pending.copy(resources = grant, showSitePrompt = false))
+              }
+            }
+            is PendingDeviceAccess.Geolocation -> denyPendingAccess()
+          }
+        },
+      )
+    }
+
   DisposableEffect(Unit) {
     onDispose {
+      denyPendingAccess()
       webView?.apply {
         stopLoading()
         if (privateMode) {

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserControls.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserControls.kt
@@ -70,6 +70,11 @@ internal data class BrowserSiteSettings(
   val popupsEnabled: Boolean = false,
   val thirdPartyCookiesEnabled: Boolean = false,
   val adBlockEnabled: Boolean = true,
+  /**
+   * Per-feature Allow (`true`) / Block (`false`). A missing entry means the site has not been asked
+   * yet, so a tab that wants that feature still prompts.
+   */
+  val deviceAccess: Map<BrowserDeviceAccess, Boolean> = emptyMap(),
 )
 
 @Composable
@@ -499,7 +504,10 @@ internal fun BrowserPageSettingsDialog(
     onDismissRequest = onDismiss,
     title = { Text("Page settings") },
     text = {
-      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Column(
+        modifier = Modifier.verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
         Text(
           text = siteLabel,
           style = MaterialTheme.typography.bodySmall,
@@ -531,6 +539,19 @@ internal fun BrowserPageSettingsDialog(
           checked = settings.adBlockEnabled,
           onCheckedChange = { onSettingsChange(settings.copy(adBlockEnabled = it)) },
         )
+        for (access in BrowserDeviceAccess.entries) {
+          SiteSettingRow(
+            label = access.settingsLabel,
+            description =
+              when (settings.allowed(access)) {
+                true -> "This site can use ${access.canUsePhrase}"
+                false -> "This site cannot use ${access.canUsePhrase}"
+                null -> "Ask when this site wants to use ${access.canUsePhrase}"
+              },
+            checked = settings.allowed(access) == true,
+            onCheckedChange = { onSettingsChange(settings.withAllowed(access, it)) },
+          )
+        }
         OutlinedButton(
           onClick = { confirmClearData = true },
           modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
@@ -549,6 +570,23 @@ internal fun BrowserPageSettingsDialog(
       }
     },
     confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
+  )
+}
+
+@Composable
+internal fun BrowserDeviceAccessDialog(
+  siteLabel: String,
+  types: Collection<BrowserDeviceAccess>,
+  onAllow: () -> Unit,
+  onBlock: () -> Unit,
+  onDismiss: () -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(deviceAccessPromptTitle(types)) },
+    text = { Text(deviceAccessPromptText(siteLabel, types)) },
+    confirmButton = { TextButton(onClick = onAllow) { Text("Allow") } },
+    dismissButton = { TextButton(onClick = onBlock) { Text("Block") } },
   )
 }
 

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccess.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccess.kt
@@ -1,0 +1,166 @@
+package com.searchlauncher.app.ui.browser
+
+import android.Manifest
+import android.os.Build
+import android.webkit.PermissionRequest
+
+/**
+ * Device features a page can ask this browser for. Each one is remembered per origin as ask / allow
+ * / block. [OTHER] is the bucket for resources WebView adds later (or names we do not model yet).
+ */
+internal enum class BrowserDeviceAccess(val prefKey: String, val settingsLabel: String) {
+  MICROPHONE("microphone", "Microphone"),
+  CAMERA("camera", "Camera"),
+  LOCATION("location", "Location"),
+  MIDI("midi", "MIDI"),
+  BLUETOOTH("bluetooth", "Bluetooth"),
+  OTHER("other", "Other devices");
+
+  /** Phrase used in "Use …?" / "wants to use …". */
+  val noun: String
+    get() =
+      when (this) {
+        MICROPHONE -> "microphone"
+        CAMERA -> "camera"
+        LOCATION -> "location"
+        MIDI -> "MIDI devices"
+        BLUETOOTH -> "Bluetooth"
+        OTHER -> "additional device access"
+      }
+
+  val canUsePhrase: String
+    get() =
+      when (this) {
+        MICROPHONE -> "the microphone"
+        CAMERA -> "the camera"
+        LOCATION -> "your location"
+        MIDI -> "MIDI devices"
+        BLUETOOTH -> "Bluetooth"
+        OTHER -> "other device features"
+      }
+}
+
+internal fun BrowserSiteSettings.allowed(access: BrowserDeviceAccess): Boolean? =
+  deviceAccess[access]
+
+internal fun BrowserSiteSettings.withAllowed(
+  access: BrowserDeviceAccess,
+  allowed: Boolean?,
+): BrowserSiteSettings =
+  copy(
+    deviceAccess =
+      if (allowed == null) deviceAccess - access else deviceAccess + (access to allowed)
+  )
+
+internal fun BrowserSiteSettings.withAllowed(
+  accesses: Collection<BrowserDeviceAccess>,
+  allowed: Boolean,
+): BrowserSiteSettings = copy(deviceAccess = deviceAccess + accesses.associateWith { allowed })
+
+/**
+ * Maps a WebView resource string to the site setting that governs it. `null` means grant without
+ * asking — today that is only the protected-media identifier used for DRM.
+ */
+internal fun deviceAccessForResource(resource: String): BrowserDeviceAccess? =
+  when (resource) {
+    PermissionRequest.RESOURCE_AUDIO_CAPTURE -> BrowserDeviceAccess.MICROPHONE
+    PermissionRequest.RESOURCE_VIDEO_CAPTURE -> BrowserDeviceAccess.CAMERA
+    PermissionRequest.RESOURCE_MIDI_SYSEX -> BrowserDeviceAccess.MIDI
+    PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID -> null
+    else ->
+      when {
+        resource.contains("BLUETOOTH", ignoreCase = true) -> BrowserDeviceAccess.BLUETOOTH
+        else -> BrowserDeviceAccess.OTHER
+      }
+  }
+
+internal data class WebResourceDecision(
+  /** Types the user has not decided yet; empty means we can settle immediately. */
+  val ask: List<BrowserDeviceAccess>,
+  /** Resources already covered by Allow, plus DRM identifiers that never prompt. */
+  val grantNow: List<String>,
+)
+
+internal fun decideWebResources(
+  requested: Array<out String>,
+  allowed: (BrowserDeviceAccess) -> Boolean?,
+): WebResourceDecision {
+  val grantNow = mutableListOf<String>()
+  val ask = linkedSetOf<BrowserDeviceAccess>()
+  for (resource in requested) {
+    val access = deviceAccessForResource(resource)
+    if (access == null) {
+      grantNow += resource
+      continue
+    }
+    when (allowed(access)) {
+      true -> grantNow += resource
+      false -> Unit
+      null -> ask += access
+    }
+  }
+  return WebResourceDecision(ask = ask.toList(), grantNow = grantNow)
+}
+
+internal fun grantableWebResources(
+  requested: Array<out String>,
+  allowed: (BrowserDeviceAccess) -> Boolean?,
+): Array<String> =
+  requested
+    .filter { resource ->
+      val access = deviceAccessForResource(resource)
+      access == null || allowed(access) == true
+    }
+    .toTypedArray()
+
+internal fun androidPermissionsFor(
+  accesses: Collection<BrowserDeviceAccess>,
+  sdk: Int = Build.VERSION.SDK_INT,
+): Array<String> {
+  val permissions = linkedSetOf<String>()
+  for (access in accesses) {
+    when (access) {
+      BrowserDeviceAccess.MICROPHONE -> permissions += Manifest.permission.RECORD_AUDIO
+      BrowserDeviceAccess.CAMERA -> permissions += Manifest.permission.CAMERA
+      BrowserDeviceAccess.LOCATION -> {
+        permissions += Manifest.permission.ACCESS_FINE_LOCATION
+        permissions += Manifest.permission.ACCESS_COARSE_LOCATION
+      }
+      BrowserDeviceAccess.BLUETOOTH ->
+        if (sdk >= Build.VERSION_CODES.S) {
+          permissions += Manifest.permission.BLUETOOTH_SCAN
+          permissions += Manifest.permission.BLUETOOTH_CONNECT
+        } else {
+          permissions += Manifest.permission.BLUETOOTH
+          permissions += Manifest.permission.BLUETOOTH_ADMIN
+          // BLE scans on Android 11 and below are location scans.
+          permissions += Manifest.permission.ACCESS_FINE_LOCATION
+        }
+      BrowserDeviceAccess.MIDI,
+      BrowserDeviceAccess.OTHER -> Unit
+    }
+  }
+  return permissions.toTypedArray()
+}
+
+internal fun androidPermissionsForResources(
+  resources: Array<out String>,
+  sdk: Int = Build.VERSION.SDK_INT,
+): Array<String> =
+  androidPermissionsFor(resources.mapNotNull(::deviceAccessForResource).toSet(), sdk)
+
+internal fun englishList(items: List<String>): String =
+  when (items.size) {
+    0 -> ""
+    1 -> items[0]
+    2 -> "${items[0]} and ${items[1]}"
+    else -> items.dropLast(1).joinToString(", ") + ", and " + items.last()
+  }
+
+internal fun deviceAccessPromptTitle(types: Collection<BrowserDeviceAccess>): String =
+  "Use ${englishList(types.map { it.noun })}?"
+
+internal fun deviceAccessPromptText(
+  siteLabel: String,
+  types: Collection<BrowserDeviceAccess>,
+): String = "$siteLabel wants to use your ${englishList(types.map { it.noun })}."

--- a/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserSiteSettingsStore.kt
+++ b/app/src/main/java/com/searchlauncher/app/ui/browser/BrowserSiteSettingsStore.kt
@@ -1,6 +1,7 @@
 package com.searchlauncher.app.ui.browser
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.net.Uri
 import java.net.URI
 
@@ -21,31 +22,50 @@ internal class BrowserSiteSettingsStore(context: Context, privateMode: Boolean) 
       popupsEnabled = prefs.getBoolean(key(origin, "popups"), false),
       thirdPartyCookiesEnabled = prefs.getBoolean(key(origin, "third_party_cookies"), false),
       adBlockEnabled = prefs.getBoolean(key(origin, "ad_block"), true),
+      deviceAccess = loadDeviceAccess(prefs, origin),
     )
   }
 
   fun save(url: String, settings: BrowserSiteSettings) {
     val origin = browserOrigin(url) ?: return
     ephemeralSettings[origin] = settings
-    preferences
-      ?.edit()
-      ?.putBoolean(key(origin, "javascript"), settings.javaScriptEnabled)
-      ?.putBoolean(key(origin, "popups"), settings.popupsEnabled)
-      ?.putBoolean(key(origin, "third_party_cookies"), settings.thirdPartyCookiesEnabled)
-      ?.putBoolean(key(origin, "ad_block"), settings.adBlockEnabled)
-      ?.apply()
+    val editor = preferences?.edit() ?: return
+    editor
+      .putBoolean(key(origin, "javascript"), settings.javaScriptEnabled)
+      .putBoolean(key(origin, "popups"), settings.popupsEnabled)
+      .putBoolean(key(origin, "third_party_cookies"), settings.thirdPartyCookiesEnabled)
+      .putBoolean(key(origin, "ad_block"), settings.adBlockEnabled)
+    for (access in BrowserDeviceAccess.entries) {
+      val accessKey = key(origin, access.prefKey)
+      val allowed = settings.deviceAccess[access]
+      if (allowed == null) editor.remove(accessKey) else editor.putBoolean(accessKey, allowed)
+    }
+    editor.apply()
   }
 
   fun reset(url: String) {
     val origin = browserOrigin(url) ?: return
     ephemeralSettings.remove(origin)
-    preferences
-      ?.edit()
-      ?.remove(key(origin, "javascript"))
-      ?.remove(key(origin, "popups"))
-      ?.remove(key(origin, "third_party_cookies"))
-      ?.remove(key(origin, "ad_block"))
-      ?.apply()
+    val editor = preferences?.edit() ?: return
+    editor
+      .remove(key(origin, "javascript"))
+      .remove(key(origin, "popups"))
+      .remove(key(origin, "third_party_cookies"))
+      .remove(key(origin, "ad_block"))
+    for (access in BrowserDeviceAccess.entries) {
+      editor.remove(key(origin, access.prefKey))
+    }
+    editor.apply()
+  }
+
+  private fun loadDeviceAccess(
+    prefs: SharedPreferences,
+    origin: String,
+  ): Map<BrowserDeviceAccess, Boolean> = buildMap {
+    for (access in BrowserDeviceAccess.entries) {
+      val accessKey = key(origin, access.prefKey)
+      if (prefs.contains(accessKey)) put(access, prefs.getBoolean(accessKey, false))
+    }
   }
 
   private fun key(origin: String, setting: String): String = "${Uri.encode(origin)}.$setting"

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserDeviceAccessTest.kt
@@ -1,0 +1,145 @@
+package com.searchlauncher.app.ui.browser
+
+import android.Manifest
+import android.os.Build
+import android.webkit.PermissionRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BrowserDeviceAccessTest {
+  @Test
+  fun mapsKnownWebViewResources() {
+    assertEquals(
+      BrowserDeviceAccess.MICROPHONE,
+      deviceAccessForResource(PermissionRequest.RESOURCE_AUDIO_CAPTURE),
+    )
+    assertEquals(
+      BrowserDeviceAccess.CAMERA,
+      deviceAccessForResource(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+    )
+    assertEquals(
+      BrowserDeviceAccess.MIDI,
+      deviceAccessForResource(PermissionRequest.RESOURCE_MIDI_SYSEX),
+    )
+    assertNull(deviceAccessForResource(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+    assertEquals(
+      BrowserDeviceAccess.BLUETOOTH,
+      deviceAccessForResource("android.webkit.resource.BLUETOOTH"),
+    )
+    assertEquals(BrowserDeviceAccess.OTHER, deviceAccessForResource("android.webkit.resource.USB"))
+  }
+
+  @Test
+  fun drmIsGrantedWithoutAskingAndBlockedTypesAreDropped() {
+    val allowed: (BrowserDeviceAccess) -> Boolean? = { access ->
+      when (access) {
+        BrowserDeviceAccess.MICROPHONE -> true
+        BrowserDeviceAccess.CAMERA -> false
+        else -> null
+      }
+    }
+    val decision =
+      decideWebResources(
+        arrayOf(
+          PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+          PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+          PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+        ),
+        allowed,
+      )
+    assertEquals(emptyList<BrowserDeviceAccess>(), decision.ask)
+    assertEquals(
+      listOf(
+        PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+        PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+      ),
+      decision.grantNow,
+    )
+  }
+
+  @Test
+  fun asksForTypesTheOriginHasNotDecided() {
+    val decision =
+      decideWebResources(
+        arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+      ) {
+        null
+      }
+    assertEquals(listOf(BrowserDeviceAccess.MICROPHONE, BrowserDeviceAccess.CAMERA), decision.ask)
+    assertEquals(emptyList<String>(), decision.grantNow)
+  }
+
+  @Test
+  fun grantableResourcesFollowStoredAllow() {
+    val settings =
+      BrowserSiteSettings(
+        deviceAccess =
+          mapOf(BrowserDeviceAccess.MICROPHONE to true, BrowserDeviceAccess.CAMERA to false)
+      )
+    assertEquals(
+      listOf(
+        PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+        PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+      ),
+      grantableWebResources(
+          arrayOf(
+            PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+          )
+        ) {
+          settings.allowed(it)
+        }
+        .toList(),
+    )
+  }
+
+  @Test
+  fun cameraAndMicrophoneNeedMatchingOsPermissions() {
+    assertEquals(
+      setOf(Manifest.permission.RECORD_AUDIO, Manifest.permission.CAMERA),
+      androidPermissionsFor(listOf(BrowserDeviceAccess.MICROPHONE, BrowserDeviceAccess.CAMERA))
+        .toSet(),
+    )
+  }
+
+  @Test
+  fun bluetoothUsesConnectScanOnModernAndroid() {
+    assertEquals(
+      setOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT),
+      androidPermissionsFor(listOf(BrowserDeviceAccess.BLUETOOTH), sdk = Build.VERSION_CODES.S)
+        .toSet(),
+    )
+  }
+
+  @Test
+  fun bluetoothScanOnOlderAndroidNeedsLocation() {
+    val permissions =
+      androidPermissionsFor(listOf(BrowserDeviceAccess.BLUETOOTH), sdk = Build.VERSION_CODES.R)
+        .toSet()
+    assertTrue(permissions.contains(Manifest.permission.BLUETOOTH))
+    assertTrue(permissions.contains(Manifest.permission.ACCESS_FINE_LOCATION))
+  }
+
+  @Test
+  fun promptCopyNamesOneTwoAndManyFeatures() {
+    assertEquals("Use camera?", deviceAccessPromptTitle(listOf(BrowserDeviceAccess.CAMERA)))
+    assertEquals(
+      "Use camera and microphone?",
+      deviceAccessPromptTitle(listOf(BrowserDeviceAccess.CAMERA, BrowserDeviceAccess.MICROPHONE)),
+    )
+    assertEquals(
+      "example.com wants to use your camera, microphone, and location.",
+      deviceAccessPromptText(
+        "example.com",
+        listOf(
+          BrowserDeviceAccess.CAMERA,
+          BrowserDeviceAccess.MICROPHONE,
+          BrowserDeviceAccess.LOCATION,
+        ),
+      ),
+    )
+  }
+}

--- a/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserSiteSettingsStoreTest.kt
+++ b/app/src/test/java/com/searchlauncher/app/ui/browser/BrowserSiteSettingsStoreTest.kt
@@ -1,0 +1,81 @@
+package com.searchlauncher.app.ui.browser
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserSiteSettingsStoreTest {
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Before
+  fun clearPrefs() {
+    context
+      .getSharedPreferences("browser_site_settings", Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .commit()
+  }
+
+  @Test
+  fun deviceAccessStartsUnsetSoTheBrowserWillAsk() {
+    val store = BrowserSiteSettingsStore(context, privateMode = false)
+    val settings = store.load("https://example.com/page")
+    for (access in BrowserDeviceAccess.entries) {
+      assertEquals(null, settings.allowed(access))
+    }
+  }
+
+  @Test
+  fun remembersAllowAndBlockPerOriginAndFeature() {
+    val store = BrowserSiteSettingsStore(context, privateMode = false)
+    store.save(
+      "https://example.com/a",
+      BrowserSiteSettings(deviceAccess = mapOf(BrowserDeviceAccess.MICROPHONE to true)),
+    )
+    store.save(
+      "https://other.test/",
+      BrowserSiteSettings(
+        deviceAccess =
+          mapOf(BrowserDeviceAccess.CAMERA to false, BrowserDeviceAccess.BLUETOOTH to true)
+      ),
+    )
+    assertEquals(true, store.load("https://example.com/b").allowed(BrowserDeviceAccess.MICROPHONE))
+    assertEquals(null, store.load("https://example.com/b").allowed(BrowserDeviceAccess.CAMERA))
+    assertEquals(false, store.load("https://other.test/path").allowed(BrowserDeviceAccess.CAMERA))
+    assertEquals(true, store.load("https://other.test/path").allowed(BrowserDeviceAccess.BLUETOOTH))
+    assertEquals(null, store.load("https://unseen.test/").allowed(BrowserDeviceAccess.MICROPHONE))
+  }
+
+  @Test
+  fun resetClearsDeviceAccessChoices() {
+    val store = BrowserSiteSettingsStore(context, privateMode = false)
+    store.save(
+      "https://example.com",
+      BrowserSiteSettings(
+        deviceAccess =
+          mapOf(BrowserDeviceAccess.MICROPHONE to true, BrowserDeviceAccess.LOCATION to false)
+      ),
+    )
+    store.reset("https://example.com/later")
+    val settings = store.load("https://example.com")
+    assertEquals(null, settings.allowed(BrowserDeviceAccess.MICROPHONE))
+    assertEquals(null, settings.allowed(BrowserDeviceAccess.LOCATION))
+  }
+
+  @Test
+  fun privateModeKeepsTheChoiceOnlyInMemory() {
+    val store = BrowserSiteSettingsStore(context, privateMode = true)
+    store.save(
+      "https://example.com",
+      BrowserSiteSettings(deviceAccess = mapOf(BrowserDeviceAccess.CAMERA to true)),
+    )
+    assertEquals(true, store.load("https://example.com").allowed(BrowserDeviceAccess.CAMERA))
+    val other = BrowserSiteSettingsStore(context, privateMode = true)
+    assertEquals(null, other.load("https://example.com").allowed(BrowserDeviceAccess.CAMERA))
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
WebView denies `getUserMedia` and similar APIs unless `WebChromeClient.onPermissionRequest` is implemented, so a tab that needed the microphone (or camera) failed without any prompt.

This adds a per-origin prompt for the device features a page can actually request:

- Microphone and camera (`RESOURCE_AUDIO_CAPTURE` / `RESOURCE_VIDEO_CAPTURE`)
- Location (`onGeolocationPermissionsShowPrompt`)
- MIDI sysex
- Bluetooth, when WebView asks for it
- Other resources WebView may add later, plus DRM identifiers which are granted without a prompt

Allow/Block is remembered per site (in memory only in a private window) and can be changed in page settings. After the site prompt, the matching OS permission is requested if the app does not already have it.

`CAMERA`, location, and Bluetooth are declared as optional features so devices without them still see the app.

Verified on the aosp30 emulator with permission.site: in-app prompts for microphone, camera, and location all appear.

[Microphone permission dialog](https://cursor.com/agents/bc-54bfa384-796c-4b0c-8314-a0ffc692290c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmicrophone_permission_dialog.webp)
[Camera permission dialog](https://cursor.com/agents/bc-54bfa384-796c-4b0c-8314-a0ffc692290c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamera_permission_dialog.webp)
[Location permission dialog](https://cursor.com/agents/bc-54bfa384-796c-4b0c-8314-a0ffc692290c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocation_permission_dialog.webp)
[browser_device_permission_prompts.mp4](https://cursor.com/agents/bc-54bfa384-796c-4b0c-8314-a0ffc692290c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbrowser_device_permission_prompts.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54bfa384-796c-4b0c-8314-a0ffc692290c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54bfa384-796c-4b0c-8314-a0ffc692290c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

